### PR TITLE
Update versions to one that rubygems.org will accept

### DIFF
--- a/.circleci/docker/Dockerfile
+++ b/.circleci/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.elastic.co/logstash/logstash:7.2.0
 COPY config /usr/share/logstash/config
 COPY pipeline /usr/share/logstash/pipeline
-COPY logstash-output-scalyr-0.1.0.pre.beta.gem /tmp
-RUN /usr/share/logstash/bin/logstash-plugin install /tmp/logstash-output-scalyr-0.1.0.pre.beta.gem
+COPY logstash-output-scalyr-0.1.2.gem /tmp
+RUN /usr/share/logstash/bin/logstash-plugin install /tmp/logstash-output-scalyr-0.1.2.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Beta
-## 0.1.0
+## 0.1.2
  - Remove special treatment of `origin` field in favor of `serverHost`
  - Change concurrency type to `single` to help guarantee one-time ordered delivery in Scalyr
  - Change default compression to `deflate`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.0.pre.beta)
+    logstash-output-scalyr (0.1.1)
       ffi (>= 1.9.25)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -82,7 +82,7 @@ GEM
     minitar (0.5.4)
     multi_json (1.13.1)
     multipart-post (2.1.1)
-    net-http-persistent (3.0.1)
+    net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
     numerizer (0.1.1)
     openssl_pkcs8_pure (0.0.0.2)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can view documentation for this plugin [on the Scalyr website](https://www.s
 # Quick start
 
 1. Build the gem, run `gem build logstash-output-scalyr.gemspec` 
-2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.0.pre.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
+2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.2.gem` or follow the latest official instructions on working with plugins from Logstash.
 3. Configure the output plugin (e.g. add it to a pipeline .conf)
 4. Restart Logstash 
 

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -161,7 +161,7 @@ class ClientSession
 
     post = Net::HTTP::Post.new uri_path
     post.add_field('Content-Type', 'application/json')
-    version = 'output-logstash-scalyr 0.1.0.beta'
+    version = 'output-logstash-scalyr 0.1.2'
     post.add_field('User-Agent', version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM)
 
     if not encoding.nil?

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.0-beta'
+  s.version         = '0.1.2'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"


### PR DESCRIPTION
A non-`pre` version, `0.1.2` because test uploads used other versions and rubygems.org does accept reuploads of previous versions even if they have been removed.