### PR TITLE
Add default parser to events

### DIFF
--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -366,6 +366,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       # Rename user-specified logfile field -> 'logfile'
       rename.call(@logfile_field, 'logfile')
 
+      # Set a default parser is none is present in the event
+      if record['parser'].to_s.empty?
+        record['parser'] = "logstashParser"
+      end
+
       # Set logfile field if empty and serverHost is supplied
       if record['logfile'].to_s.empty? and serverHost
         record['logfile'] = "/logstash/#{serverHost}"

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -120,6 +120,7 @@ describe LogStash::Outputs::Scalyr do
                                                      "tag_prefix_t1" => "true",
                                                      "tag_prefix_t2" => "true",
                                                      "tag_prefix_t3" => "true",
+                                                     "parser" => "logstashParser",
                                                  })
       end
     end
@@ -142,6 +143,7 @@ describe LogStash::Outputs::Scalyr do
                                                      'source_host' => 'my host 3',
                                                      'serverHost' => 'Logstash',
                                                      "tags" => ["t1", "t2", "t3"],
+                                                     "parser" => "logstashParser",
                                                  })
       end
     end


### PR DESCRIPTION
Adding a default parser to any message that passes through the logstash output plugin. The default is being attached to the event and not as a server field since the user would have no way to remove the server field one even if they want to define their own. I have no idea how two parsers on one event would work but its something we want to avoid anyway.