### PR TITLE
Update README and comment to suggest correct EU scalyr endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the above example, the Logstash pipeline defines a file input that reads from
 
 ---
 
-- If your Scalyr backend is located in other geographies (such as Europe which would use `https://eu.scalyr.com/`), you may need to modify this
+- If you have an EU-based Scalyr account, please use https://eu.scalyr.com/
 
 `config :scalyr_server, :validate => :string, :default => "https://agent.scalyr.com/"`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In the above example, the Logstash pipeline defines a file input that reads from
 
 ---
 
-- If your Scalyr backend is located in other geographies (such as Europe which would use `https://agent.eu.scalyr.com/`), you may need to modify this
+- If your Scalyr backend is located in other geographies (such as Europe which would use `https://eu.scalyr.com/`), you may need to modify this
 
 `config :scalyr_server, :validate => :string, :default => "https://agent.scalyr.com/"`
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -33,7 +33,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # The Scalyr API write token, these are available at https://www.scalyr.com/keys.  This is the only compulsory configuration field required for proper upload
   config :api_write_token, :validate => :string, :required => true
 
-  # If your Scalyr backend is located in other geographies (such as Europe which would use `https://agent.eu.scalyr.com/`), you may need to modify this
+  # If your Scalyr backend is located in other geographies (such as Europe which would use `https://eu.scalyr.com/`), you may need to modify this
   config :scalyr_server, :validate => :string, :default => "https://agent.scalyr.com/"
 
   # Path to SSL bundle file.

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -33,7 +33,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # The Scalyr API write token, these are available at https://www.scalyr.com/keys.  This is the only compulsory configuration field required for proper upload
   config :api_write_token, :validate => :string, :required => true
 
-  # If your Scalyr backend is located in other geographies (such as Europe which would use `https://eu.scalyr.com/`), you may need to modify this
+  # If you have an EU-based Scalyr account, please use https://eu.scalyr.com/
   config :scalyr_server, :validate => :string, :default => "https://agent.scalyr.com/"
 
   # Path to SSL bundle file.


### PR DESCRIPTION
Documentation was suggesting `agent.eu.scalyr.com` as the endpoint to use for uploading EU logs, but this endpoint doesn't exist. This just changes a comment and the README to reflect the correct `eu.scalyr.com`. Since this is purely a documentation change no release is needed.