### PR TITLE
Optionally recreate quantile estimators on send, avoid printing `nil`

### DIFF
--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -53,7 +53,7 @@ class ClientSession
 
   def initialize(logger, add_events_uri, compression_type, compression_level,
                  ssl_verify_peer, ssl_ca_bundle_path, ssl_verify_depth, append_builtin_cert,
-                 record_stats_for_status)
+                 record_stats_for_status, flush_quantile_estimates_on_status_send)
     @logger = logger
     @add_events_uri = add_events_uri  # typically /addEvents
     @compression_type = compression_type
@@ -63,6 +63,7 @@ class ClientSession
     @append_builtin_cert = append_builtin_cert
     @ssl_verify_depth = ssl_verify_depth
     @record_stats_for_status = record_stats_for_status
+    @flush_quantile_estimates_on_status_send = flush_quantile_estimates_on_status_send
 
     # A cert to use by default to avoid issues caused by the OpenSSL library not validating certs according to standard
     @cert_string = "" \
@@ -186,7 +187,9 @@ class ClientSession
     current_stats[:bytes_sent_p90] = @latency_stats[:bytes_sent].query(0.9)
     current_stats[:bytes_sent_p99] = @latency_stats[:bytes_sent].query(0.99)
 
-    @latency_stats = get_new_latency_stats
+    if @flush_quantile_estimates_on_status_send
+      @latency_stats = get_new_latency_stats
+    end
     current_stats
   end
 

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -87,7 +87,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
         status_event = plugin.send_status
         puts status_event[:attrs]["message"]
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20, total_requests_failed=10, total_request_bytes_sent=100, total_compressed_request_bytes_sent=50, total_response_bytes_received=100, total_request_latency_secs=100, total_connections_created=10, total_serialization_duration_secs=100.500, total_compression_duration_secs=10.200, total_flatten_values_duration_secs=33.300, compression_type=deflate, compression_level=9, total_multi_receive_secs=0, multi_receive_duration_p50=10, multi_receive_duration_p90=18, multi_receive_duration_p99=19, multi_receive_event_count_p50=, multi_receive_event_count_p90=, multi_receive_event_count_p99=")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20, total_requests_failed=10, total_request_bytes_sent=100, total_compressed_request_bytes_sent=50, total_response_bytes_received=100, total_request_latency_secs=100, total_connections_created=10, total_serialization_duration_secs=100.500, total_compression_duration_secs=10.200, total_flatten_values_duration_secs=33.300, compression_type=deflate, compression_level=9, total_multi_receive_secs=0, multi_receive_duration_p50=10, multi_receive_duration_p90=18, multi_receive_duration_p99=19, multi_receive_event_count_p50=0, multi_receive_event_count_p90=0, multi_receive_event_count_p99=0")
       end
 
       it "send_stats is called when events list is empty, but otherwise noop" do


### PR DESCRIPTION
New config option `flush_quantile_estimates_on_status_send` which defaults to false will control if we recreate all the estimators when we sent the status. I'm not sure how these estimators work on the inside so I'm not sure of the effects of observing all the stats for the entire plugin runtime.

This PR also avoids printing the `nil` values the estimators return when there is no data, printing `0` instead.