### PR TITLE
Add support for logging status messages to stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   data to Scalyr by setting ``log_status_messages_to_stdout`` config option. By default those
   lines are logged under INFO log level and you may need to enable / configure pluggin logging
   as per https://www.elastic.co/guide/en/logstash/current/logging.html.
+- Update metric reporting code to round float values to 4 decimal points so we also record sub
+  millisecond values for per event metrics.
 
 ## 0.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Beta
+
+## 0.1.9
+
+- Add support for logging status messages with metrics to stdout in addition to sending this
+  data to Scalyr by setting ``log_status_messages_to_stdout`` config option. By default those
+  lines are logged under INFO log level and you may need to enable / configure pluggin logging
+  as per https://www.elastic.co/guide/en/logstash/current/logging.html.
+
 ## 0.1.8
 
 - Add additional metrics.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ The changelog should also be updated with the latest version and changes of note
 To deploy the current code on your machine run these commands:
 
 ```
+rm -rf vendor/
 bundle check --path vendor/bundle || bundle install --deployment
 curl -u RUBY_USER:RUBY_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can view documentation for this plugin [on the Scalyr website](https://app.s
 # Quick start
 
 1. Build the gem, run `gem build logstash-output-scalyr.gemspec` 
-2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.8.gem` or follow the latest official instructions on working with plugins from Logstash.
+2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.9.gem` or follow the latest official instructions on working with plugins from Logstash.
 3. Configure the output plugin (e.g. add it to a pipeline .conf)
 4. Restart Logstash 
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -694,14 +694,14 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       msg = 'plugin_status: '
       cnt = 0
       @client_session.get_stats.each do |k, v|
-        val = v.instance_of?(Float) ? sprintf("%.3f", v) : v
+        val = v.instance_of?(Float) ? sprintf("%.4f", v) : v
         val = val.nil? ? 0 : val
         msg << ' ' if cnt > 0
         msg << "#{k.to_s}=#{val}"
         cnt += 1
       end
       get_stats.each do |k, v|
-        val = v.instance_of?(Float) ? sprintf("%.3f", v) : v
+        val = v.instance_of?(Float) ? sprintf("%.4f", v) : v
         val = val.nil? ? 0 : val
         msg << ' ' if cnt > 0
         msg << "#{k.to_s}=#{val}"

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -109,6 +109,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # minutes.
   config :status_report_interval, :validate => :number, :default => 300
 
+  # Set to true to also log status messages with various metrics to stdout in addition to sending
+  # this data to Scalyr
+  config :log_status_messages_to_stdout, :validate => :boolean, :default => false
+
   # Whether or not to count status event uploads in the statistics such as request latency etc.
   config :record_stats_for_status, :validate => :boolean, :default => false
 
@@ -710,6 +714,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     multi_event_request = create_multi_event_request([status_event], nil, nil)
     @client_session.post_add_events(multi_event_request[:body], true, 0)
     @last_status_transmit_time = Time.now()
+
+    if @log_status_messages_to_stdout
+      @logger.info msg
+    end
     status_event
   end
 

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -275,7 +275,7 @@ class ClientSession
 
     post = Net::HTTP::Post.new uri_path
     post.add_field('Content-Type', 'application/json')
-    version = 'output-logstash-scalyr 0.1.8'
+    version = 'output-logstash-scalyr 0.1.9'
     post.add_field('User-Agent', version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM)
 
     if not encoding.nil?

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.8'
+  s.version         = '0.1.9'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -88,7 +88,7 @@ describe LogStash::Outputs::Scalyr do
         plugin1.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
 
         status_event = plugin1.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.500 total_compression_duration_secs=10.200 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0")
       end
 
       it "returns and sends correct status event on send_stats on initial and subsequent send" do
@@ -115,7 +115,7 @@ describe LogStash::Outputs::Scalyr do
 
         plugin.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
         status_event = plugin.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.500 total_compression_duration_secs=10.200 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
       end
 
       it "send_stats is called when events list is empty, but otherwise noop" do


### PR DESCRIPTION
This pull request adds support for logging status messages with metrics to stdout in addition to sending this data to Scalyr.

We log those messages using logger INFO level and don't directly print them stdout (we could do that, but I think the convention is to use logger abstraction so log routing and filtering is handled as configured inside logstash config).

This means user may need to configure their logging configuration (https://www.elastic.co/guide/en/logstash/current/logging.html) to ensure log level for the plugin is set to ``INFO``.

This information could be utilized for local monitoring / similar.