### PR TITLE
Update plugin to be thread-safe and support shared concurrency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,8 @@ workflows:
     jobs:
       - smoketest-git-dev
       - smoketest-rubygems-stable
+      - smoketest-git-dev-single-worker
+      - smoketest-rubygems-stable-single-worker
       - unittest
       - microbenchmarks-jruby
       - microbenchmarks-cruby

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,28 @@ jobs: # a collection of steps
             gemfile=$(ls *.gem)
             echo "Using gemfile: ${gemfile}"
             cp $gemfile .circleci/docker/
-            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker
+            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker 8
+
+  smoketest-git-dev-single-worker:
+    docker:
+      - image: circleci/jruby:9.2.7.0-jdk
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - checkout # special step to check out source code to working directory
+      - run:
+          name: Build gem
+          command: |
+            gem build logstash-output-scalyr.gemspec
+            # We rename the file so we don't need to hard code version in Dockerfile
+            mv logstash-output-scalyr-*.gem logstash-output-scalyr.gem
+      - run:
+          name: Run smoketest script which first builds another Docker Logstash image and installs our gem
+          command: |
+            gemfile=$(ls *.gem)
+            echo "Using gemfile: ${gemfile}"
+            cp $gemfile .circleci/docker/
+            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker 1
 
   # Job which runs basic smoke tests against latest stable version on RubyGems
   # to ensure something didn't get messed up during the publish process
@@ -82,7 +103,31 @@ jobs: # a collection of steps
             gemfile=$(ls *.gem)
             echo "Using gemfile: ${gemfile}"
             cp $gemfile .circleci/docker/
-            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker
+            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker 8
+
+  smoketest-rubygems-stable-single-worker:
+    docker:
+      - image: circleci/jruby:9.2.7.0-jdk
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - checkout # special step to check out source code to working directory
+      - run:
+          name: Download Gem from RubyGems
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y jq
+            LATEST_VERSION=$(curl https://rubygems.org/api/v1/versions/logstash-output-scalyr/latest.json | jq .version | tr -d '"')
+            wget https://rubygems.org/downloads/logstash-output-scalyr-${LATEST_VERSION}.gem
+            # We rename the file so we don't need to hard code version in Dockerfile
+            mv logstash-output-scalyr-*.gem logstash-output-scalyr.gem
+      - run:
+          name: Run smoketest script which first builds another Docker Logstash image and installs our gem
+          command: |
+            gemfile=$(ls *.gem)
+            echo "Using gemfile: ${gemfile}"
+            cp $gemfile .circleci/docker/
+            source .circleci/smoketest_logstash.sh yarnsh/agent-testing:latest 300 $gemfile .circleci/docker 1
 
   # NOTE: We need to use large resource class since for jRuby benchmark we pre-generate and store
   # large dataset in memory

--- a/.circleci/docker/config/pipelines.yml
+++ b/.circleci/docker/config/pipelines.yml
@@ -10,6 +10,6 @@
 - pipeline.id: scalyr
   pipeline.batch.size: 100
   pipeline.batch.delay: 50
-  pipeline.workers: 8
+  pipeline.workers: WORKER_COUNT
   queue.type: persisted
   path.config: "/usr/share/logstash/pipeline/scalyr.conf"

--- a/.circleci/docker/config/pipelines.yml
+++ b/.circleci/docker/config/pipelines.yml
@@ -10,6 +10,6 @@
 - pipeline.id: scalyr
   pipeline.batch.size: 100
   pipeline.batch.delay: 50
-  pipeline.workers: 1
+  pipeline.workers: 8
   queue.type: persisted
   path.config: "/usr/share/logstash/pipeline/scalyr.conf"

--- a/.circleci/docker/pipeline/scalyr.conf
+++ b/.circleci/docker/pipeline/scalyr.conf
@@ -18,7 +18,6 @@ output {
    api_write_token => 'SCALYR_API_KEY'
    scalyr_server => 'SCALYR_SERVER'
    ssl_verify_peer => true
-   ssl_verify_depth => 5
    serverhost_field => 'host'
    ssl_ca_bundle_path => '/etc/pki/tls/certs/ca-bundle.crt'
    logfile_field => 'path'

--- a/.circleci/smoketest_logstash.sh
+++ b/.circleci/smoketest_logstash.sh
@@ -38,6 +38,9 @@ gemfile=$3
 # 3. gemfile of scalyr logstash plugin
 logstash_docker_context=$4
 
+# How many workers to configure for this test, to allow testing single and multi threaded
+worker_count=$5
+
 # We don't have an easy way to update base test docker images which come bundled
 # with the smoketest.py file
 # (.circleci/docker_unified_smoke_unit/smoketest/smoketest.py ->
@@ -98,6 +101,7 @@ pushd $logstash_docker_context
 perl -pi.bak -e "s{ORIGIN1_INFILE}{$monitored_logfile1}" pipeline/scalyr.conf
 perl -pi.bak -e "s{SCALYR_API_KEY}{$SCALYR_API_KEY}" pipeline/scalyr.conf
 perl -pi.bak -e "s{SCALYR_SERVER}{$SCALYR_SERVER}" pipeline/scalyr.conf
+perl -pi.bak -e "s{WORKER_COUNT}{$worker_count}" config/pipelines.yml
 docker build -t ${agent_image} .
 popd
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Beta
 
-## 0.1.10
+## 0.1.10.beta
 
 - Switch to shared concurrency to allow the use of multiple worker threads for increased
   throughput.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beta
 
+## 0.1.10
+
+- Switch to shared concurrency to allow the use of multiple worker threads for increased
+  throughput.
+- Switch HTTP client library to `manticore` to work better with new shared concurrency.
+
 ## 0.1.9
 
 - Add support for logging status messages with metrics to stdout in addition to sending this

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ end
 gem 'pry'
 gem 'pry-nav'
 gem 'quantile'
+gem 'manticore', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.9)
+    logstash-output-scalyr (0.1.10.beta)
       ffi (>= 1.9.18)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.8)
+    logstash-output-scalyr (0.1.9)
       ffi (>= 1.9.18)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -143,6 +143,7 @@ PLATFORMS
 DEPENDENCIES
   logstash-devutils
   logstash-output-scalyr!
+  manticore
   pry
   pry-nav
   quantile

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -689,15 +689,14 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # uploading to Scalyr over time.
   def send_status
 
-    @send_stats.synchronize do
-      status_event = {
-        :ts => (Time.now.to_f * (10**9)).round,
-        :attrs => {
-          'logfile' => "scalyr_logstash.log",
-          'plugin_id' => self.id,
-        }
+    status_event = {
+      :ts => (Time.now.to_f * (10**9)).round,
+      :attrs => {
+        'logfile' => "scalyr_logstash.log",
+        'plugin_id' => self.id,
       }
-
+    }
+    @send_stats.synchronize do
       if !@last_status_transmit_time
         status_event[:attrs]['message'] = "Started Scalyr LogStash output plugin."
         status_event[:attrs]['serverHost'] = @node_hostname
@@ -725,15 +724,15 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         status_event[:attrs]['serverHost'] = @node_hostname
         status_event[:attrs]['parser'] = @status_parser
       end
-      multi_event_request = create_multi_event_request([status_event], nil, nil)
-      @client_session.post_add_events(multi_event_request[:body], true, 0)
-      @last_status_transmit_time = Time.now()
-
-      if @log_status_messages_to_stdout
-        @logger.info msg
-      end
-      status_event
     end
+    multi_event_request = create_multi_event_request([status_event], nil, nil)
+    @client_session.post_add_events(multi_event_request[:body], true, 0)
+    @last_status_transmit_time = Time.now()
+
+    if @log_status_messages_to_stdout
+      @logger.info msg
+    end
+    status_event
   end
 
   # Returns true if we should sample and record metrics for a specific event based on the sampling

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -133,6 +133,12 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # these stas this might be wanted or not.
   config :flush_quantile_estimates_on_status_send, :validate => :boolean, :default => false
 
+  def initialize(*params)
+    super
+    # Request statistics are accumulated across multiple threads and must be accessed through a mutex
+    @stats_lock = Mutex.new
+  end
+
   def close
     @running = false
     @client_session.close if @client_session
@@ -214,8 +220,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     @last_status_transmit_time = nil
     @last_status_ = false
 
-    # Request statistics are accumulated across multiple threads and must be accessed through a mutex
-    @stats_lock = Mutex.new
     # Plugin level (either per batch or event level metrics). Other request
     # level metrics are handled by the HTTP Client class.
     @multi_receive_statistics = {

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -132,6 +132,13 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # after no work being done.
   config :noop_mode, :validate => :boolean, :default => false
 
+  # Manticore related options
+  config :connect_timeout, :validate => :number, :default => 10
+  config :socket_timeout, :validate => :number, :default => 10
+  config :request_timeout, :validate => :number, :default => 60
+  config :pool_max, :validate => :number, :default => 50
+  config :pool_max_per_route, :validate => :number, :default => 25
+
   def initialize(*params)
     super
     # Request statistics are accumulated across multiple threads and must be accessed through a mutex
@@ -232,7 +239,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     @client_session = Scalyr::Common::Client::ClientSession.new(
         @logger, @add_events_uri,
         @compression_type, @compression_level, @ssl_verify_peer, @ssl_ca_bundle_path, @append_builtin_cert,
-        @record_stats_for_status, @flush_quantile_estimates_on_status_send
+        @record_stats_for_status, @flush_quantile_estimates_on_status_send,
+        @connect_timeout, @socket_timeout, @request_timeout, @pool_max, @pool_max_per_route
     )
 
     @logger.info("Started Scalyr output plugin", :class => self.class.name)

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 require "logstash/outputs/base"
 require "logstash/namespace"
-require "logstash/plugin_mixins/http_client"
 require "concurrent"
 require "stud/buffer"
 require "socket" # for Socket.gethostname
@@ -9,9 +8,7 @@ require "thread" # for safe queueing
 require "uri" # for escaping user input
 require 'json' # for converting event object to JSON for upload
 
-require 'net/http'
-require 'net/http/persistent'
-require 'net/https'
+require 'manticore'
 require 'rbzip2'
 require 'zlib'
 require 'stringio'
@@ -25,7 +22,6 @@ require "scalyr/common/util"
 # Implements the Scalyr output plugin
 #---------------------------------------------------------------------------------------------------------------------
 class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
-  include LogStash::PluginMixins::HttpClient
 
   config_name "scalyr"
 
@@ -234,7 +230,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     # create a client session for uploading to Scalyr
     @running = true
     @client_session = Scalyr::Common::Client::ClientSession.new(
-        client_config, @logger, @add_events_uri,
+        @logger, @add_events_uri,
         @compression_type, @compression_level, @ssl_verify_peer, @ssl_ca_bundle_path, @append_builtin_cert,
         @record_stats_for_status, @flush_quantile_estimates_on_status_send
     )

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -88,7 +88,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # Whether or not to verify the connection to Scalyr, only set to false for debugging.
   config :ssl_verify_peer, :validate => :boolean, :default => true
 
-  # If we should append our built-in Scalyr cert to the one we find at `cacert`.
+  # Path to SSL bundle file.
+  config :ssl_ca_bundle_path, :validate => :string, :default => "/etc/ssl/certs/ca-bundle.crt"
+
+  # If we should append our built-in Scalyr cert to the one we find at `ssl_ca_bundle_path`.
   config :append_builtin_cert, :validate => :boolean, :default => true
 
   config :max_request_buffer, :validate => :number, :default => 5500000  # echee TODO: eliminate?
@@ -232,7 +235,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     @running = true
     @client_session = Scalyr::Common::Client::ClientSession.new(
         client_config, @logger, @add_events_uri,
-        @compression_type, @compression_level, @ssl_verify_peer, @append_builtin_cert,
+        @compression_type, @compression_level, @ssl_verify_peer, @ssl_ca_bundle_path, @append_builtin_cert,
         @record_stats_for_status, @flush_quantile_estimates_on_status_send
     )
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -617,7 +617,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   def create_multi_event_request(scalyr_events, current_threads, current_logs)
 
     body = {
-      :session => @session_id,
+      :session => @session_id + Thread.current.object_id.to_s,
       :token => @api_write_token,
       :events => scalyr_events,
     }

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -133,11 +133,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   config :noop_mode, :validate => :boolean, :default => false
 
   # Manticore related options
-  config :connect_timeout, :validate => :number, :default => 10
-  config :socket_timeout, :validate => :number, :default => 10
-  config :request_timeout, :validate => :number, :default => 60
-  config :pool_max, :validate => :number, :default => 50
-  config :pool_max_per_route, :validate => :number, :default => 25
+  config :http_connect_timeout, :validate => :number, :default => 10
+  config :http_socket_timeout, :validate => :number, :default => 10
+  config :http_request_timeout, :validate => :number, :default => 60
+  config :http_pool_max, :validate => :number, :default => 50
+  config :http_pool_max_per_route, :validate => :number, :default => 25
 
   def initialize(*params)
     super
@@ -240,7 +240,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         @logger, @add_events_uri,
         @compression_type, @compression_level, @ssl_verify_peer, @ssl_ca_bundle_path, @append_builtin_cert,
         @record_stats_for_status, @flush_quantile_estimates_on_status_send,
-        @connect_timeout, @socket_timeout, @request_timeout, @pool_max, @pool_max_per_route
+        @http_connect_timeout, @http_socket_timeout, @http_request_timeout, @http_pool_max, @http_pool_max_per_route
     )
 
     @logger.info("Started Scalyr output plugin", :class => self.class.name)

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -53,7 +53,8 @@ class ClientSession
 
   def initialize(logger, add_events_uri, compression_type, compression_level,
                  ssl_verify_peer, ssl_ca_bundle_path, append_builtin_cert,
-                 record_stats_for_status, flush_quantile_estimates_on_status_send)
+                 record_stats_for_status, flush_quantile_estimates_on_status_send,
+                 connect_timeout, socket_timeout, request_timeout, pool_max, pool_max_per_route)
     @logger = logger
     @add_events_uri = add_events_uri  # typically /addEvents
     @compression_type = compression_type
@@ -63,6 +64,11 @@ class ClientSession
     @append_builtin_cert = append_builtin_cert
     @record_stats_for_status = record_stats_for_status
     @flush_quantile_estimates_on_status_send = flush_quantile_estimates_on_status_send
+    @connect_timeout = connect_timeout
+    @socket_timeout = socket_timeout
+    @request_timeout = request_timeout
+    @pool_max = pool_max
+    @pool_max_per_route = pool_max_per_route
 
     # A cert to use by default to avoid issues caused by the OpenSSL library not validating certs according to standard
     @cert_string = "" \
@@ -131,15 +137,15 @@ class ClientSession
     # TODO: Eventually expose some more of these as config options, though nothing here really needs tuning normally
     # besides SSL
     c = {
-      connect_timeout: 10,
-      socket_timeout: 10,
-      request_timeout: 60,
+      connect_timeout: @connect_timeout,
+      socket_timeout: @socket_timeout,
+      request_timeout: @request_timeout,
       follow_redirects: true,
       automatic_retries: 1,
       retry_non_idempotent: false,
       check_connection_timeout: 200,
-      pool_max: 50,
-      pool_max_per_route: 25,
+      pool_max: @pool_max,
+      pool_max_per_route: @pool_max_per_route,
       cookies: true,
       keepalive: true,
       ssl: {}

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -295,7 +295,7 @@ class ClientSession
       compression_duration = end_time - start_time
     end
 
-    version = 'output-logstash-scalyr 0.1.9'
+    version = 'output-logstash-scalyr 0.1.10.beta'
     post_headers = {
       'Content-Type': 'application/json',
       'User-Agent': version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -141,8 +141,7 @@ class ClientSession
     rescue OpenSSL::SSL::SSLError => e
       raise e
 
-    # TODO: we shouldn't be seeing this anymore, figure out what to replace it with
-    rescue Net::HTTP::Persistent::Error => e
+    rescue Manticore::ManticoreException => e
       # The underlying persistent-connection library automatically retries when there are network-related errors.
       # Eventually, it will give up and raise this generic error, at which time, we convert it to a ClientError
       raise ClientError.new(e.message, @add_events_uri)

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -228,6 +228,8 @@ class ClientSession
       bytes_received = response.body.bytesize  # echee: double check
         # echee TODO add more statistics
 
+    # TODO: Manticore doesn't raise SSL errors as this but as "UnknownExceptions", need to dig in and see if there is a
+    # way to detect that it is from SSL.
     rescue OpenSSL::SSL::SSLError => e
       raise e
 

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -52,13 +52,15 @@ end
 class ClientSession
 
   def initialize(client_config, logger, add_events_uri, compression_type, compression_level,
-                 ssl_verify_peer, append_builtin_cert, record_stats_for_status, flush_quantile_estimates_on_status_send)
+                 ssl_verify_peer, ssl_ca_bundle_path, append_builtin_cert,
+                 record_stats_for_status, flush_quantile_estimates_on_status_send)
     @client_config = client_config
     @logger = logger
     @add_events_uri = add_events_uri  # typically /addEvents
     @compression_type = compression_type
     @compression_level = compression_level
     @ssl_verify_peer = ssl_verify_peer
+    @ssl_ca_bundle_path = ssl_ca_bundle_path
     @append_builtin_cert = append_builtin_cert
     @record_stats_for_status = record_stats_for_status
     @flush_quantile_estimates_on_status_send = flush_quantile_estimates_on_status_send
@@ -133,8 +135,8 @@ class ClientSession
     if @ssl_verify_peer
       c[:ssl][:verify] = :strict
       @ca_cert = Tempfile.new("ca_cert")
-      if !c[:ssl][:ca_file].nil? and File.file?(c[:ssl][:ca_file])
-        @ca_cert.write(File.read(c[:ssl][:ca_file]))
+      if File.file?(@ssl_ca_bundle_path)
+        @ca_cert.write(File.read(@ssl_ca_bundle_path))
         @ca_cert.flush
       end
       if @append_builtin_cert

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -52,60 +52,13 @@ end
 class ClientSession
 
   def initialize(logger, add_events_uri, compression_type, compression_level,
-                 ssl_verify_peer, ssl_ca_bundle_path, ssl_verify_depth, append_builtin_cert,
                  record_stats_for_status, flush_quantile_estimates_on_status_send)
     @logger = logger
     @add_events_uri = add_events_uri  # typically /addEvents
     @compression_type = compression_type
     @compression_level = compression_level
-    @ssl_verify_peer = ssl_verify_peer
-    @ssl_ca_bundle_path = ssl_ca_bundle_path
-    @append_builtin_cert = append_builtin_cert
-    @ssl_verify_depth = ssl_verify_depth
     @record_stats_for_status = record_stats_for_status
     @flush_quantile_estimates_on_status_send = flush_quantile_estimates_on_status_send
-
-    # A cert to use by default to avoid issues caused by the OpenSSL library not validating certs according to standard
-    @cert_string = "" \
-        "-----BEGIN CERTIFICATE-----\n" \
-        "MIIG6zCCBNOgAwIBAgIJAM5aknNWtN6oMA0GCSqGSIb3DQEBCwUAMIGpMQswCQYD\n" \
-        "VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEXMBUGA1UEBxMOUG9ydG9sYSBW\n" \
-        "YWxsZXkxEzARBgNVBAoTClNjYWx5ciBJbmMxFTATBgNVBAsTDFNjYWx5ciBBZ2Vu\n" \
-        "dDEdMBsGA1UEAxMUU2NhbHlyIEFnZW50IENBIFJvb3QxITAfBgkqhkiG9w0BCQEW\n" \
-        "EmNvbnRhY3RAc2NhbHlyLmNvbTAeFw0xNDA5MDkyMTUyMDVaFw0yNDA5MDYyMTUy\n" \
-        "MDVaMIGpMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEXMBUGA1UE\n" \
-        "BxMOUG9ydG9sYSBWYWxsZXkxEzARBgNVBAoTClNjYWx5ciBJbmMxFTATBgNVBAsT\n" \
-        "DFNjYWx5ciBBZ2VudDEdMBsGA1UEAxMUU2NhbHlyIEFnZW50IENBIFJvb3QxITAf\n" \
-        "BgkqhkiG9w0BCQEWEmNvbnRhY3RAc2NhbHlyLmNvbTCCAiIwDQYJKoZIhvcNAQEB\n" \
-        "BQADggIPADCCAgoCggIBALdNamcMNVxkIB6qVWmNCi1jeyeqOX00rYAWDlyBHff7\n" \
-        "vU833Evuixgrf0HxrOQNiPsOK66ehG6LfJd2UIBDEHBCXRo+aeFQLrCLIVXiqJ2W\n" \
-        "Tvl7dUU9d7zfw/XXif3lMQTiyQAWYTyjfugDczEScEUk93EWFfW47j9PTGh96yKm\n" \
-        "nVbfOxD4XbN0ykdo85cs7M/NOHQj4q34l77XGXrit+nb1cL3wS9ZzJG8s40J2+Dp\n" \
-        "LUA8KBQuvim6hfqrjaDX0bXVvc52a7TSh/zb58gkLbiqvBuPo5P8PBLHCx8bJtZu\n" \
-        "fjWRdjaftgw7CcsdIuMhbm3823WI/A+/p4s1B5KOPqOYRkgG8FBqFIRTecKAV5wC\n" \
-        "Z2ruTytoOUBWItrheyJhm+99X1I2y/6mdecBdk7j3+8U+nCsGHkH5Jwjl2BH9tfT\n" \
-        "RUhVTCQs25XLNm41kZo7xK464xZsJKHXj9jr5gLIdF6CgzU2uYsQHKcw1pAVITLe\n" \
-        "bfGEob8AcL0E7+1hurRjyYxtxZpsZeGMwI0/BStT+fLEAOJ1byGUgSUbhi9lJ8Hc\n" \
-        "+NZDfaCaCZKRxjePCqeWjZUUdVoH3fNSi2GuNLqtOFzxlkP5tBErnXufE6XZAtEQ\n" \
-        "lv/9qxa4ZLsvhbt+6qQryIAHL4aReh/VReER438ARdwG2QDK+vRfhNpke69em5Kb\n" \
-        "AgMBAAGjggESMIIBDjAdBgNVHQ4EFgQUENX6MjnzqTJdTQMAEakSdXV/I80wgd4G\n" \
-        "A1UdIwSB1jCB04AUENX6MjnzqTJdTQMAEakSdXV/I82hga+kgawwgakxCzAJBgNV\n" \
-        "BAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRcwFQYDVQQHEw5Qb3J0b2xhIFZh\n" \
-        "bGxleTETMBEGA1UEChMKU2NhbHlyIEluYzEVMBMGA1UECxMMU2NhbHlyIEFnZW50\n" \
-        "MR0wGwYDVQQDExRTY2FseXIgQWdlbnQgQ0EgUm9vdDEhMB8GCSqGSIb3DQEJARYS\n" \
-        "Y29udGFjdEBzY2FseXIuY29tggkAzlqSc1a03qgwDAYDVR0TBAUwAwEB/zANBgkq\n" \
-        "hkiG9w0BAQsFAAOCAgEAmmgm1AeO7wfuR36HHgpZCKZxboRFwc2FzKaHNSg2FQ0G\n" \
-        "MuOP6HZUQWsaXLe0Kc8emJKrIwrn6x2jMm19Bjbps2bPW6ao6UE/6fb5Z7CX82IX\n" \
-        "pKlDDH6OfYjDplBzoqf5PkPgxZNyiZ7nyNUWz+P2vesLFVynmej2MvLIZVnEJ2Wp\n" \
-        "xzyHMKQo92DP8yNEudoK8QQpoLcuNcAli9blt8+NIV9RSDrI9CvArLNpZJMlS1Vx\n" \
-        "gdzEU3wEQYWc36j3XCsp7ZDvgTm6FpyHS5ccMpXR1E62tVINGX9r+97ZHyxjqurb\n" \
-        "606y1FzV/5Mf/aihPYSSreq63UVqdsaQfyS77Q4tpJofq875w8nd2Vs3guDs2T0h\n" \
-        "1bOlV3e2HfglWsHKwNguQZo2nfMUp11IYfV/HOKWNQkbrPhuayXMi3i2wCZe9JNt\n" \
-        "P9uZ2OjzsVu2QFcSlvZF6y02/bjbNATRfj/J/SHNFyCDu6bXhtAu0yZzFLiOZxjD\n" \
-        "LwzunBMoWcJj+P2Vx3OhbE9FMyMeKdOWdTgiI1GLEkfJi6s7d/tk1ayLmbBTRD/e\n" \
-        "XkjSeLBss6mA1INuE1+gKVA4MABsUiLqGZ8xCPN16CyPcTqL2TJFo1IOqivMxKDh\n" \
-        "H4Z/mHoGi5SRnye+Wo+jyiQiWjJQ5LrlQPbHmuO0tLs9lM1t9nhzLifzga5F4+o=\n" \
-        "-----END CERTIFICATE-----"
 
     # Request statistics are accumulated across multiple threads and must be accessed through a mutex
     @stats_lock = Mutex.new
@@ -126,28 +79,6 @@ class ClientSession
         :compression_type => @compression_type,
         :compression_level => @compression_level,
     }
-
-    @http = Net::HTTP::Persistent.new
-
-    # verify peers to prevent potential MITM attacks
-    if @ssl_verify_peer
-      @ca_cert = Tempfile.new("ca_cert")
-      if File.file?(@ssl_ca_bundle_path)
-        @ca_cert.write(File.read(@ssl_ca_bundle_path))
-        @ca_cert.flush
-      end
-      if @append_builtin_cert
-        open(@ca_cert.path, 'a') do |f|
-          f.puts @cert_string
-        end
-      end
-      @ca_cert.flush
-      @http.ca_file = @ca_cert.path
-      @http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-      @http.verify_depth = @ssl_verify_depth
-    else
-      @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    end
   end  # def initialize
 
   # Convenience method to create a fresh quantile estimator
@@ -190,36 +121,27 @@ class ClientSession
 
 
   # Upload data to Scalyr. Assumes that the body size complies with Scalyr limits
-  def post_add_events(body, is_status, body_serialization_duration = 0)
-    post, compression_duration = prepare_post_object @add_events_uri.path, body
+  def post_add_events(client, body, is_status, body_serialization_duration = 0)
+    post_body, post_headers, compression_duration = prepare_post_object @add_events_uri.path, body
     fail_count = 1  # putative assume failure
     start_time = Time.now
     uncompressed_bytes_sent = 0
     compressed_bytes_sent = 0
     bytes_received = 0
     begin
-      response = @http.request(@add_events_uri, post)
+      response = client.send(:post, @add_events_uri, body: post_body, headers: post_headers)
       handle_response(response)
 
       fail_count -= 1  # success means we negate the putative failure
       uncompressed_bytes_sent = (body.bytesize + @add_events_uri.path.bytesize)
-      compressed_bytes_sent = (post.body.bytesize + @add_events_uri.path.bytesize)
+      compressed_bytes_sent = (post_body.bytesize + @add_events_uri.path.bytesize)
       bytes_received = response.body.bytesize  # echee: double check
         # echee TODO add more statistics
 
     rescue OpenSSL::SSL::SSLError => e
-      if @ssl_verify_peer and @ssl_ca_bundle_path.nil? and !File.file?(@ca_cert.path)
-        @ca_cert.synchronize do
-          @ca_cert = Tempfile.new("ca_cert")
-          @ca_cert.write(@cert_string)
-          @ca_cert.flush
-          @http.ca_file = @ca_cert.path
-        end
-        raise ClientError.new("Packaged certificate appears to have been deleted, writing a new one.", @add_events_uri)
-      else
-        raise e
-      end
+      raise e
 
+    # TODO: we shouldn't be seeing this anymore, figure out what to replace it with
     rescue Net::HTTP::Persistent::Error => e
       # The underlying persistent-connection library automatically retries when there are network-related errors.
       # Eventually, it will give up and raise this generic error, at which time, we convert it to a ClientError
@@ -249,7 +171,6 @@ class ClientSession
 
 
   def close
-    @http.shutdown
   end  # def close
 
 
@@ -277,18 +198,20 @@ class ClientSession
       compression_duration = end_time - start_time
     end
 
-    post = Net::HTTP::Post.new uri_path
-    post.add_field('Content-Type', 'application/json')
     version = 'output-logstash-scalyr 0.1.9'
-    post.add_field('User-Agent', version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM)
+    post_headers = {
+      'Content-Type': 'application/json',
+      'User-Agent': version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM
+    }
 
+    post_body = nil
     if not encoding.nil?
-      post.add_field('Content-Encoding', encoding)
-      post.body = compressed_body
+      post_headers['Content-Encoding'] = encoding
+      post_body = compressed_body
     else
-      post.body = body
+      post_body = body
     end
-    return post, compression_duration
+    return post_body, post_headers, compression_duration
   end  # def prepare_post_object
 
 

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -51,14 +51,59 @@ end
 #---------------------------------------------------------------------------------------------------------------------
 class ClientSession
 
-  def initialize(logger, add_events_uri, compression_type, compression_level,
-                 record_stats_for_status, flush_quantile_estimates_on_status_send)
+  def initialize(client_config, logger, add_events_uri, compression_type, compression_level,
+                 ssl_verify_peer, append_builtin_cert, record_stats_for_status, flush_quantile_estimates_on_status_send)
+    @client_config = client_config
     @logger = logger
     @add_events_uri = add_events_uri  # typically /addEvents
     @compression_type = compression_type
     @compression_level = compression_level
+    @ssl_verify_peer = ssl_verify_peer
+    @append_builtin_cert = append_builtin_cert
     @record_stats_for_status = record_stats_for_status
     @flush_quantile_estimates_on_status_send = flush_quantile_estimates_on_status_send
+
+    # A cert to use by default to avoid issues caused by the OpenSSL library not validating certs according to standard
+    @cert_string = "" \
+        "-----BEGIN CERTIFICATE-----\n" \
+        "MIIG6zCCBNOgAwIBAgIJAM5aknNWtN6oMA0GCSqGSIb3DQEBCwUAMIGpMQswCQYD\n" \
+        "VQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEXMBUGA1UEBxMOUG9ydG9sYSBW\n" \
+        "YWxsZXkxEzARBgNVBAoTClNjYWx5ciBJbmMxFTATBgNVBAsTDFNjYWx5ciBBZ2Vu\n" \
+        "dDEdMBsGA1UEAxMUU2NhbHlyIEFnZW50IENBIFJvb3QxITAfBgkqhkiG9w0BCQEW\n" \
+        "EmNvbnRhY3RAc2NhbHlyLmNvbTAeFw0xNDA5MDkyMTUyMDVaFw0yNDA5MDYyMTUy\n" \
+        "MDVaMIGpMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEXMBUGA1UE\n" \
+        "BxMOUG9ydG9sYSBWYWxsZXkxEzARBgNVBAoTClNjYWx5ciBJbmMxFTATBgNVBAsT\n" \
+        "DFNjYWx5ciBBZ2VudDEdMBsGA1UEAxMUU2NhbHlyIEFnZW50IENBIFJvb3QxITAf\n" \
+        "BgkqhkiG9w0BCQEWEmNvbnRhY3RAc2NhbHlyLmNvbTCCAiIwDQYJKoZIhvcNAQEB\n" \
+        "BQADggIPADCCAgoCggIBALdNamcMNVxkIB6qVWmNCi1jeyeqOX00rYAWDlyBHff7\n" \
+        "vU833Evuixgrf0HxrOQNiPsOK66ehG6LfJd2UIBDEHBCXRo+aeFQLrCLIVXiqJ2W\n" \
+        "Tvl7dUU9d7zfw/XXif3lMQTiyQAWYTyjfugDczEScEUk93EWFfW47j9PTGh96yKm\n" \
+        "nVbfOxD4XbN0ykdo85cs7M/NOHQj4q34l77XGXrit+nb1cL3wS9ZzJG8s40J2+Dp\n" \
+        "LUA8KBQuvim6hfqrjaDX0bXVvc52a7TSh/zb58gkLbiqvBuPo5P8PBLHCx8bJtZu\n" \
+        "fjWRdjaftgw7CcsdIuMhbm3823WI/A+/p4s1B5KOPqOYRkgG8FBqFIRTecKAV5wC\n" \
+        "Z2ruTytoOUBWItrheyJhm+99X1I2y/6mdecBdk7j3+8U+nCsGHkH5Jwjl2BH9tfT\n" \
+        "RUhVTCQs25XLNm41kZo7xK464xZsJKHXj9jr5gLIdF6CgzU2uYsQHKcw1pAVITLe\n" \
+        "bfGEob8AcL0E7+1hurRjyYxtxZpsZeGMwI0/BStT+fLEAOJ1byGUgSUbhi9lJ8Hc\n" \
+        "+NZDfaCaCZKRxjePCqeWjZUUdVoH3fNSi2GuNLqtOFzxlkP5tBErnXufE6XZAtEQ\n" \
+        "lv/9qxa4ZLsvhbt+6qQryIAHL4aReh/VReER438ARdwG2QDK+vRfhNpke69em5Kb\n" \
+        "AgMBAAGjggESMIIBDjAdBgNVHQ4EFgQUENX6MjnzqTJdTQMAEakSdXV/I80wgd4G\n" \
+        "A1UdIwSB1jCB04AUENX6MjnzqTJdTQMAEakSdXV/I82hga+kgawwgakxCzAJBgNV\n" \
+        "BAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRcwFQYDVQQHEw5Qb3J0b2xhIFZh\n" \
+        "bGxleTETMBEGA1UEChMKU2NhbHlyIEluYzEVMBMGA1UECxMMU2NhbHlyIEFnZW50\n" \
+        "MR0wGwYDVQQDExRTY2FseXIgQWdlbnQgQ0EgUm9vdDEhMB8GCSqGSIb3DQEJARYS\n" \
+        "Y29udGFjdEBzY2FseXIuY29tggkAzlqSc1a03qgwDAYDVR0TBAUwAwEB/zANBgkq\n" \
+        "hkiG9w0BAQsFAAOCAgEAmmgm1AeO7wfuR36HHgpZCKZxboRFwc2FzKaHNSg2FQ0G\n" \
+        "MuOP6HZUQWsaXLe0Kc8emJKrIwrn6x2jMm19Bjbps2bPW6ao6UE/6fb5Z7CX82IX\n" \
+        "pKlDDH6OfYjDplBzoqf5PkPgxZNyiZ7nyNUWz+P2vesLFVynmej2MvLIZVnEJ2Wp\n" \
+        "xzyHMKQo92DP8yNEudoK8QQpoLcuNcAli9blt8+NIV9RSDrI9CvArLNpZJMlS1Vx\n" \
+        "gdzEU3wEQYWc36j3XCsp7ZDvgTm6FpyHS5ccMpXR1E62tVINGX9r+97ZHyxjqurb\n" \
+        "606y1FzV/5Mf/aihPYSSreq63UVqdsaQfyS77Q4tpJofq875w8nd2Vs3guDs2T0h\n" \
+        "1bOlV3e2HfglWsHKwNguQZo2nfMUp11IYfV/HOKWNQkbrPhuayXMi3i2wCZe9JNt\n" \
+        "P9uZ2OjzsVu2QFcSlvZF6y02/bjbNATRfj/J/SHNFyCDu6bXhtAu0yZzFLiOZxjD\n" \
+        "LwzunBMoWcJj+P2Vx3OhbE9FMyMeKdOWdTgiI1GLEkfJi6s7d/tk1ayLmbBTRD/e\n" \
+        "XkjSeLBss6mA1INuE1+gKVA4MABsUiLqGZ8xCPN16CyPcTqL2TJFo1IOqivMxKDh\n" \
+        "H4Z/mHoGi5SRnye+Wo+jyiQiWjJQ5LrlQPbHmuO0tLs9lM1t9nhzLifzga5F4+o=\n" \
+        "-----END CERTIFICATE-----"
 
     # Request statistics are accumulated across multiple threads and must be accessed through a mutex
     @stats_lock = Mutex.new
@@ -80,6 +125,35 @@ class ClientSession
         :compression_level => @compression_level,
     }
   end  # def initialize
+
+  def modified_client_config
+    c = @client_config
+
+    # verify peers to prevent potential MITM attacks
+    if @ssl_verify_peer
+      c[:ssl][:verify] = :strict
+      @ca_cert = Tempfile.new("ca_cert")
+      if !c[:ssl][:ca_file].nil? and File.file?(c[:ssl][:ca_file])
+        @ca_cert.write(File.read(c[:ssl][:ca_file]))
+        @ca_cert.flush
+      end
+      if @append_builtin_cert
+        open(@ca_cert.path, 'a') do |f|
+          f.puts @cert_string
+        end
+      end
+      @ca_cert.flush
+      c[:ssl][:ca_file] = @ca_cert.path
+    else
+      c[:ssl][:verify] = :disable
+    end
+
+    c
+  end
+
+  def client
+    @client ||= Manticore::Client.new(modified_client_config)
+  end
 
   # Convenience method to create a fresh quantile estimator
   def get_new_latency_stats
@@ -121,7 +195,7 @@ class ClientSession
 
 
   # Upload data to Scalyr. Assumes that the body size complies with Scalyr limits
-  def post_add_events(client, body, is_status, body_serialization_duration = 0)
+  def post_add_events(body, is_status, body_serialization_duration = 0)
     post_body, post_headers, compression_duration = prepare_post_object @add_events_uri.path, body
     fail_count = 1  # putative assume failure
     start_time = Time.now

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.9'
+  s.version         = '0.1.10.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -24,7 +24,7 @@ describe LogStash::Outputs::Scalyr do
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
               plugin.register
               plugin.multi_receive(sample_events)
-            }.to raise_error(OpenSSL::SSL::SSLError, "certificate verify failed")
+            }.to raise_error(Scalyr::Common::Client::ClientError, "Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty")
         end
       end
 
@@ -38,7 +38,7 @@ describe LogStash::Outputs::Scalyr do
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'append_builtin_cert' => false})
               plugin.register
               plugin.multi_receive(sample_events)
-            }.to raise_error(OpenSSL::SSL::SSLError, "certificate verify failed")
+            }.to raise_error(Scalyr::Common::Client::ClientError, "Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty")
           end
           ensure
             `sudo mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_DIR}`
@@ -65,7 +65,7 @@ describe LogStash::Outputs::Scalyr do
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'scalyr_server' => 'https://invalid.mitm.should.fail.test.agent.scalyr.com:443'})
               plugin.register
               plugin.multi_receive(sample_events)
-            }.to raise_error(OpenSSL::SSL::SSLError, "hostname \"invalid.mitm.should.fail.test.agent.scalyr.com\" does not match the server certificate")
+            }.to raise_error(Scalyr::Common::Client::ClientError, "Host name 'invalid.mitm.should.fail.test.agent.scalyr.com' does not match the certificate subject provided by the peer (CN=*.scalyr.com)")
           ensure
             # Clean up the hosts file
             `sudo truncate -s 0 /etc/hosts`

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -78,6 +78,7 @@ describe LogStash::Outputs::Scalyr do
         mock_client_session = MockClientSession.new
         plugin1.instance_variable_set(:@last_status_transmit_time, 100)
         plugin1.instance_variable_set(:@client_session, mock_client_session)
+        plugin1.instance_variable_set(:@session_id, "some_session_id")
         plugin1.instance_variable_set(:@plugin_metrics, {
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
@@ -95,6 +96,7 @@ describe LogStash::Outputs::Scalyr do
         # 1. Initial send
         plugin.instance_variable_set(:@last_status_transmit_time, nil)
         plugin.instance_variable_set(:@client_session, mock_client_session)
+        plugin.instance_variable_set(:@session_id, "some_session_id")
         status_event = plugin.send_status
         expect(status_event[:attrs]["message"]).to eq("Started Scalyr LogStash output plugin.")
 
@@ -138,6 +140,7 @@ describe LogStash::Outputs::Scalyr do
         # 1. Initial send
         plugin.instance_variable_set(:@last_status_transmit_time, nil)
         plugin.instance_variable_set(:@client_session, mock_client_session)
+        plugin.instance_variable_set(:@session_id, "some_session_id")
         expect(mock_client_session).to receive(:post_add_events).with(anything, true, anything)
         plugin.send_status
 


### PR DESCRIPTION
The HTTP library seems to be threadsafe to begin with, which leaves only metrics gathering and the SSL certificate error fallback codepath to update. This is as far as I can tell of course, and care should be taken to make sure we look over it all and don't miss anything.

The PRNG is also not threadsafe but it is functional for non-security purposes.