### PR TITLE
Error handling improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ if Dir.exist?(logstash_path) && use_logstash_source
   gem 'logstash-core-plugin-api', :path => "#{logstash_path}/logstash-core-plugin-api"
 end
 
+group :test do
+  gem "webmock"
+end
+
 gem 'pry'
 gem 'pry-nav'
 gem 'quantile'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
     clamp (0.6.5)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.5)
+    crack (0.4.5)
+      rexml
     diff-lcs (1.3)
     elasticsearch (5.0.5)
       elasticsearch-api (= 5.0.5)
@@ -34,6 +38,7 @@ GEM
     fivemat (1.3.7)
     gem_publisher (1.5.0)
     gems (0.8.3)
+    hashdiff (1.0.1)
     i18n (0.6.9)
     insist (1.0.0)
     jar-dependencies (0.4.0)
@@ -95,6 +100,7 @@ GEM
       spoon (~> 0.0)
     pry-nav (0.3.0)
       pry (>= 0.9.10, < 0.13.0)
+    public_suffix (4.0.6)
     puma (2.16.0-java)
     quantile (0.2.1)
     rack (1.6.6)
@@ -102,6 +108,7 @@ GEM
       rack
     rake (12.3.2)
     rbzip2 (0.3.0)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -134,6 +141,10 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
+    webmock (3.13.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   java
@@ -147,6 +158,7 @@ DEPENDENCIES
   pry
   pry-nav
   quantile
+  webmock
 
 BUNDLED WITH
    2.2.18

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -290,8 +290,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       records_count = events.to_a.length
 
       while !multi_event_request_array.to_a.empty?
+        multi_event_request = multi_event_request_array.pop
         begin
-          multi_event_request = multi_event_request_array.pop
           # For some reason a retry on the multi_receive may result in the request array containing `nil` elements, we
           # ignore these.
           if !multi_event_request.nil?

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -368,6 +368,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           :error_class => e.class.name,
           :backtrace => e.backtrace
       )
+    end
   end  # def multi_receive
 
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -321,8 +321,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             :payload_size => multi_event_request[:body].bytesize,
             :will_retry_in_seconds => sleep_interval,
         }
-        exc_data[:code] = e.response_code if e.code
-        exc_data[:body] = e.response_body if @logger.debug? and e.body
+        exc_data[:code] = e.code if e.code
+        exc_data[:body] = e.body if @logger.debug? and e.body
         exc_data[:payload] = "\tSample payload: #{request[:body][0,1024]}..." if @logger.debug?
         if e.is_commonly_retried?
           # well-known retriable errors should be debug

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -256,7 +256,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       :multi_receive_duration_secs => Quantile::Estimator.new,
       :multi_receive_event_count => Quantile::Estimator.new,
       :event_attributes_count => Quantile::Estimator.new,
-      :flatten_values_duration_secs => Quantile::Estimator.new
+      :flatten_values_duration_secs => Quantile::Estimator.new,
+      :batches_per_multi_receive => Quantile::Estimator.new
     }
   end
 
@@ -351,6 +352,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         @multi_receive_statistics[:total_multi_receive_secs] += (Time.now.to_f - start_time)
         @plugin_metrics[:multi_receive_duration_secs].observe(Time.now.to_f - start_time)
         @plugin_metrics[:multi_receive_event_count].observe(records_count)
+        @plugin_metrics[:batches_per_multi_receive].observe(total_batches)
       end
     end
 
@@ -675,6 +677,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       current_stats[:event_attributes_count_p50] = @plugin_metrics[:event_attributes_count].query(0.5)
       current_stats[:event_attributes_count_p90] = @plugin_metrics[:event_attributes_count].query(0.9)
       current_stats[:event_attributes_count_p99] = @plugin_metrics[:event_attributes_count].query(0.99)
+
+      current_stats[:batches_per_multi_receive_p50] = @plugin_metrics[:batches_per_multi_receive].query(0.5)
+      current_stats[:batches_per_multi_receive_p90] = @plugin_metrics[:batches_per_multi_receive].query(0.9)
+      current_stats[:batches_per_multi_receive_p99] = @plugin_metrics[:batches_per_multi_receive].query(0.99)
 
       if @flatten_nested_values
         # We only return those metrics in case flattening is enabled

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -301,15 +301,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             result.push(multi_event_request)
           end
 
-        rescue OpenSSL::SSL::SSLError => e
-          # cannot rely on exception message, so we always log the following warning
-          @logger.error "SSL certificate verification failed.  " +
-          "Please make sure your certificate bundle is configured correctly and points to a valid file.  " +
-          "You can configure this with the ssl_ca_bundle_path configuration option.  " +
-          "The current value of ssl_ca_bundle_path is '#{@ssl_ca_bundle_path}'"
-          @logger.error e.message
-          @logger.error "Discarding buffer chunk without retrying."
-
         rescue Scalyr::Common::Client::ServerError, Scalyr::Common::Client::ClientError => e
           sleep_interval = sleep_for(sleep_interval)
           message = "Error uploading to Scalyr (will backoff-retry)"

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -27,6 +27,7 @@ describe LogStash::Outputs::Scalyr do
         it "throws a ServerError due to fake api key" do
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234'})
               plugin.register
+              plugin.instance_variable_set(:@running, false)
               expect(plugin.instance_variable_get(:@logger)).to receive(:error).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :batch_num=>1,
@@ -47,6 +48,7 @@ describe LogStash::Outputs::Scalyr do
         it "throws an SSLError" do
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
               plugin.register
+              plugin.instance_variable_set(:@running, false)
               expect(plugin.instance_variable_get(:@logger)).to receive(:error).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :batch_num=>1,
@@ -70,6 +72,7 @@ describe LogStash::Outputs::Scalyr do
           begin
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'append_builtin_cert' => false})
               plugin.register
+              plugin.instance_variable_set(:@running, false)
               expect(plugin.instance_variable_get(:@logger)).to receive(:error).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :batch_num=>1,
@@ -106,6 +109,7 @@ describe LogStash::Outputs::Scalyr do
           begin
               plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'scalyr_server' => 'https://invalid.mitm.should.fail.test.agent.scalyr.com:443'})
               plugin.register
+              plugin.instance_variable_set(:@running, false)
               expect(plugin.instance_variable_get(:@logger)).to receive(:error).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :batch_num=>1,
@@ -135,6 +139,7 @@ describe LogStash::Outputs::Scalyr do
 
         plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
         plugin.register
+        plugin.instance_variable_set(:@running, false)
 
         allow(plugin.instance_variable_get(:@logger)).to receive(:debug)
         plugin.multi_receive(sample_events)
@@ -160,6 +165,7 @@ describe LogStash::Outputs::Scalyr do
 
         plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
         plugin.register
+        plugin.instance_variable_set(:@running, false)
 
         allow(plugin.instance_variable_get(:@logger)).to receive(:error)
         plugin.multi_receive(sample_events)

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -83,13 +83,14 @@ describe LogStash::Outputs::Scalyr do
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,
-          :flatten_values_duration_secs => Quantile::Estimator.new
+          :flatten_values_duration_secs => Quantile::Estimator.new,
+          :batches_per_multi_receive => Quantile::Estimator.new
         })
         plugin1.instance_variable_get(:@plugin_metrics)[:multi_receive_duration_secs].observe(1)
         plugin1.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
 
         status_event = plugin1.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0")
       end
 
       it "returns and sends correct status event on send_stats on initial and subsequent send" do
@@ -108,7 +109,8 @@ describe LogStash::Outputs::Scalyr do
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,
-          :flatten_values_duration_secs => Quantile::Estimator.new
+          :flatten_values_duration_secs => Quantile::Estimator.new,
+          :batches_per_multi_receive => Quantile::Estimator.new
         })
 
         (1..20).each do |n|
@@ -117,7 +119,7 @@ describe LogStash::Outputs::Scalyr do
 
         plugin.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
         status_event = plugin.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
       end
 
       it "send_stats is called when events list is empty, but otherwise noop" do
@@ -151,7 +153,8 @@ describe LogStash::Outputs::Scalyr do
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,
-          :flatten_values_duration_secs => Quantile::Estimator.new
+          :flatten_values_duration_secs => Quantile::Estimator.new,
+          :batches_per_multi_receive => Quantile::Estimator.new
         })
         (1..20).each do |n|
           plugin.instance_variable_get(:@plugin_metrics)[:multi_receive_duration_secs].observe(n)


### PR DESCRIPTION
Adds error catching when sending status messages.
Reverts a small testing change that made it in, one log was going to `error` when it should have been going to `debug`.
Adds a quantile metric for how many batches we split `multi_receive` calls into.
Fixes retries, popping the event we want to retry was inside the retry block so it ended up lost on retry.