### PR TITLE
Include plugin version in the startup + status message

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you want to change status reporting interval you can do that by changing the
 ## Updating version
 
 Currently references to the version need to be manually updated, files to look in for this are `logstash-putput-scalyr.gemspec`,
- `client.rb`, twice in the CircleCI `Dockerfile`, and under "Quick Start" in this `README.md`.
+ `client.rb`, twice in `scalyr.rb`, twice in the CircleCI `Dockerfile`, and under "Quick Start" in this `README.md`.
 
 The changelog should also be updated with the latest version and changes of note.
 

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If you want to change status reporting interval you can do that by changing the
 ## Updating version
 
 Currently references to the version need to be manually updated, files to look in for this are `logstash-putput-scalyr.gemspec`,
- `client.rb`, twice in `scalyr.rb`, twice in the CircleCI `Dockerfile`, and under "Quick Start" in this `README.md`.
+ `lib/scalyr/constants.rb`, twice in the CircleCI `Dockerfile`, and under "Quick Start" in this `README.md`.
 
 The changelog should also be updated with the latest version and changes of note.
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -243,7 +243,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         @http_connect_timeout, @http_socket_timeout, @http_request_timeout, @http_pool_max, @http_pool_max_per_route
     )
 
-    @logger.info("Started Scalyr output plugin", :class => self.class.name)
+    # TODO: Define version constant in one place and use this everywhere
+    @logger.info("Started Scalyr output plugin (v0.1.10.beta)", :class => self.class.name)
 
     # Finally, send a status line to Scalyr
     send_status
@@ -710,7 +711,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     }
     @send_stats.synchronize do
       if !@last_status_transmit_time
-        status_event[:attrs]['message'] = "Started Scalyr LogStash output plugin."
+        status_event[:attrs]['message'] = "Started Scalyr LogStash output plugin (v0.1.10.beta)."
         status_event[:attrs]['serverHost'] = @node_hostname
       else
         cur_time = Time.now()

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -16,6 +16,7 @@ require 'quantile'
 
 require 'scalyr/common/client'
 require "scalyr/common/util"
+require "scalyr/constants"
 
 
 #---------------------------------------------------------------------------------------------------------------------
@@ -243,8 +244,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         @http_connect_timeout, @http_socket_timeout, @http_request_timeout, @http_pool_max, @http_pool_max_per_route
     )
 
-    # TODO: Define version constant in one place and use this everywhere
-    @logger.info("Started Scalyr output plugin (v0.1.10.beta)", :class => self.class.name)
+    @logger.info(sprintf("Started Scalyr output plugin (%s)." % [PLUGIN_VERSION]), :class => self.class.name)
 
     # Finally, send a status line to Scalyr
     send_status
@@ -711,7 +711,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     }
     @send_stats.synchronize do
       if !@last_status_transmit_time
-        status_event[:attrs]['message'] = "Started Scalyr LogStash output plugin (v0.1.10.beta)."
+        status_event[:attrs]['message'] = sprintf("Started Scalyr LogStash output plugin (%s)." % [PLUGIN_VERSION])
         status_event[:attrs]['serverHost'] = @node_hostname
       else
         cur_time = Time.now()

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -1,3 +1,5 @@
+require "scalyr/constants"
+
 module Scalyr; module Common; module Client
 
 #---------------------------------------------------------------------------------------------------------------------
@@ -295,7 +297,7 @@ class ClientSession
       compression_duration = end_time - start_time
     end
 
-    version = 'output-logstash-scalyr 0.1.10.beta'
+    version = sprintf('output-logstash-scalyr %s' % [PLUGIN_VERSION])
     post_headers = {
       'Content-Type': 'application/json',
       'User-Agent': version + ';' + RUBY_VERSION + ';' + RUBY_PLATFORM

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+PLUGIN_VERSION = "v0.1.10.beta"

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -98,7 +98,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.instance_variable_set(:@client_session, mock_client_session)
         plugin.instance_variable_set(:@session_id, "some_session_id")
         status_event = plugin.send_status
-        expect(status_event[:attrs]["message"]).to eq("Started Scalyr LogStash output plugin.")
+        expect(status_event[:attrs]["message"]).to eq("Started Scalyr LogStash output plugin (v0.1.10.beta).")
 
         # 2. Second send
         plugin.instance_variable_set(:@last_status_transmit_time, 100)


### PR DESCRIPTION
Small change to include plugin version in the startup + initial status message.

While at it, we should probably also clean up the code and define a constant with version and reference that everywhere where possible instead of copy + paste :D