### PR TITLE
Expand synchronization in `send_status` to avoid duplicate uploads

### DIFF
--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -781,19 +781,19 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         status_event[:attrs]['serverHost'] = @node_hostname
         status_event[:attrs]['parser'] = @status_parser
       end
+      multi_event_request = create_multi_event_request([status_event], nil, nil)
+      begin
+        @client_session.post_add_events(multi_event_request[:body], true, 0)
+      rescue => e
+        @logger.warn(
+          "Unexpected error occurred while uploading status to Scalyr",
+          :error_message => e.message,
+          :error_class => e.class.name
+        )
+        return
+      end
+      @last_status_transmit_time = Time.now()
     end
-    multi_event_request = create_multi_event_request([status_event], nil, nil)
-    begin
-      @client_session.post_add_events(multi_event_request[:body], true, 0)
-    rescue => e
-      @logger.warn(
-        "Unexpected error occurred while uploading status to Scalyr",
-        :error_message => e.message,
-        :error_class => e.class.name
-      )
-      return
-    end
-    @last_status_transmit_time = Time.now()
 
     if @log_status_messages_to_stdout
       @logger.info msg


### PR DESCRIPTION
Updating of the last send time was done outside of synchronization, which left a window in which could allow a duplicate status to be sent from multiple threads.