### PR TITLE
Log the response body in cases of bad parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beta
 
+## TBD
+- Log truncated error body for all errors to help with debugging.
+
 ## 0.1.13
 - Fix synchronization of status message sending code to avoid duplicate logs.
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -330,7 +330,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           exc_data[:code] = e.code if e.code
           if @logger.debug? and e.body
             exc_data[:body] = e.body
-          elsif e.message == "Invalid JSON response from server" and e.body
+          elsif (e.message == "Invalid JSON response from server" or e.message == "error/client/badParam") and e.body
             exc_data[:body] = Scalyr::Common::Util.truncate(e.body, 512)
           end
           exc_data[:payload] = "\tSample payload: #{request[:body][0,1024]}..." if @logger.debug?
@@ -785,11 +785,20 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       begin
         @client_session.post_add_events(multi_event_request[:body], true, 0)
       rescue => e
-        @logger.warn(
-          "Unexpected error occurred while uploading status to Scalyr",
-          :error_message => e.message,
-          :error_class => e.class.name
-        )
+        if (e.message == "Invalid JSON response from server" or e.message == "error/client/badParam") and e.body
+          @logger.warn(
+            "Unexpected error occurred while uploading status to Scalyr",
+            :error_message => e.message,
+            :error_class => e.class.name,
+            :body => Scalyr::Common::Util.truncate(e.body, 512)
+          )
+        else
+          @logger.warn(
+            "Unexpected error occurred while uploading status to Scalyr",
+            :error_message => e.message,
+            :error_class => e.class.name
+          )
+        end
         return
       end
       @last_status_transmit_time = Time.now()

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -330,7 +330,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           exc_data[:code] = e.code if e.code
           if @logger.debug? and e.body
             exc_data[:body] = e.body
-          elsif (e.message == "Invalid JSON response from server" or e.message == "error/client/badParam") and e.body
+          elsif e.body
             exc_data[:body] = Scalyr::Common::Util.truncate(e.body, 512)
           end
           exc_data[:payload] = "\tSample payload: #{request[:body][0,1024]}..." if @logger.debug?
@@ -785,7 +785,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       begin
         @client_session.post_add_events(multi_event_request[:body], true, 0)
       rescue => e
-        if (e.message == "Invalid JSON response from server" or e.message == "error/client/badParam") and e.body
+        if e.body
           @logger.warn(
             "Unexpected error occurred while uploading status to Scalyr",
             :error_message => e.message,

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -37,7 +37,8 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://agent.scalyr.com/addEvents",
-                  :will_retry_in_seconds=>2
+                  :will_retry_in_seconds=>2,
+                  :body=>"{\n  \"message\": \"Couldn't decode API token ...234.\",\n  \"status\": \"error/client/badParam\"\n}"
                 }
               )
               plugin.multi_receive(sample_events)


### PR DESCRIPTION
Also extends existing "Invalid JSON response" body logging to status upload errors.

Not sure if adding more cases for specific errors is the way to approach this. Perhaps a config options for logging error bodies for all errors?