### PR TITLE
Client status sending improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Beta
 
+## 0.1.15.beta
+- Only call ``send_status`` method at the end of ``multi_receive()`` if there is at least one
+  record in the batch.
+- Update ``register()`` method to use a separate short-lived client session for sending initial
+  client status.
+
 ## 0.1.14.beta
 - Add configurable max retries for requests when running into errors.
 - Add ability to send messages to the dead letter queue if we exhaust all retries and if it is configured.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.15.beta
 - Only call ``send_status`` method at the end of ``multi_receive()`` if there is at least one
-  record in the batch.
+  record in the batch when ``report_status_for_empty_batches`` config option is set to ``false``.
 - Update ``register()`` method to use a separate short-lived client session for sending initial
   client status.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.14.beta)
+    logstash-output-scalyr (0.1.15.beta)
       ffi (>= 1.9.18)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -392,9 +392,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           @plugin_metrics[:multi_receive_event_count].observe(records_count)
           @plugin_metrics[:batches_per_multi_receive].observe(total_batches)
         end
+
+        send_status
       end
 
-      send_status
       return result
 
     rescue => e

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -109,6 +109,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # minutes.
   config :status_report_interval, :validate => :number, :default => 300
 
+  # True to also call send_status when multi_receive() is called with no events.
+  # In some situations (e.g. when logstash is configured with multiple scalyr
+  # plugins conditionally where most are idle) you may want to set this to false
+  config :report_status_for_empty_batches, :validate => :boolean, :default => true
+
   # Set to true to also log status messages with various metrics to stdout in addition to sending
   # this data to Scalyr
   config :log_status_messages_to_stdout, :validate => :boolean, :default => false
@@ -403,7 +408,9 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           @plugin_metrics[:multi_receive_event_count].observe(records_count)
           @plugin_metrics[:batches_per_multi_receive].observe(total_batches)
         end
+      end
 
+      if @report_status_for_empty_batches or records_count > 0
         send_status
       end
 

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -267,6 +267,7 @@ class ClientSession
 
 
   def close
+    @client.close if @client
   end  # def close
 
 

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.1.14.beta"
+PLUGIN_VERSION = "v0.1.15.beta"

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.14.beta'
+  s.version         = '0.1.15.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -122,7 +122,7 @@ describe LogStash::Outputs::Scalyr do
         expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
       end
 
-      it "send_stats is called when events list is empty, but otherwise noop" do
+      it "send_stats is not called when events list is empty" do
         quantile_estimator = Quantile::Estimator.new
         plugin.instance_variable_set(:@plugin_metrics, {
           :multi_receive_duration_secs => Quantile::Estimator.new,
@@ -131,7 +131,7 @@ describe LogStash::Outputs::Scalyr do
           :flatten_values_duration_secs => Quantile::Estimator.new
         })
         plugin.instance_variable_set(:@client_session, mock_client_session)
-        expect(plugin).to receive(:send_status)
+        expect(plugin).not_to receive(:send_status)
         expect(quantile_estimator).not_to receive(:observe)
         expect(mock_client_session).not_to receive(:post_add_events)
         plugin.multi_receive([])


### PR DESCRIPTION
This pull request includes two changes which should help with client status reporting in case single logstash instance has many conditional scalyr outputs configured out of which most are idle.

It includes two changes:

1. Use a separate short lived client session and connection for initial client status / hello to scalyr server. This way we avoid long lived connection open in case there are no other batches / events send to this instance of the plugin.
2. Only call ``send_status()`` for batches which contain at least one event. This should be fine for as long as plugin instance gets some data, but it will allow us to not reporting status messages with all values being 0 for idle output instances (this can happen because logstash intentionally sends empty batches to plugin sometimes for keep alive and other reasons). It does mean that technically we would not send a status in case there is no traffic for a while, but I don't think should be a problem.