### PR TITLE
Fix for the client.client_config race condition

### DIFF
--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -269,6 +269,13 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     send_status(initial_send_status_client_session)
     initial_send_status_client_session.close
 
+    # We also "prime" the main HTTP client here, one which is used for sending subsequent requests.
+    # Here priming just means setting up the client parameters without opening any connections.
+    # Since client writes certs to a temporary file there could be a race in case we don't do that
+    # here since multi_receive() is multi threaded. An alternative would be to put a look around
+    # client init method (aka client_config())
+    @client_session.client
+
   end # def register
 
   # Convenience method to create a fresh quantile estimator

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -138,8 +138,8 @@ class ClientSession
   end  # def initialize
 
   def client_config
-    # TODO: Eventually expose some more of these as config options, though nothing here really needs tuning normally
-    # besides SSL
+    # NOTE: This method is not thread safe and needs to be called only once in synchronized manner in case
+    # multiple threads re-use the same client instance and post_add_events() method.
     c = {
       connect_timeout: @connect_timeout,
       socket_timeout: @socket_timeout,


### PR DESCRIPTION
A workaround which I believe should fix the race condition with client initialization.

We simply initialize it in ``register()`` (same as before although it happened "unintentionally" before) method which doesn't need to be thread safe (unlike ``multi_receive()``).