### PR TITLE
Convert bigints to strings to avoid JSON generator errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,9 @@ jobs: # a collection of steps
             echo "Metrics recording results:"
             ruby spec/benchmarks/metrics_overhead.rb
             echo ""
+            echo "Bignum converting results:"
+            ruby spec/benchmarks/bignum_fixing.rb
+            echo ""
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Beta
 
+## TBD
+- Catch errors relating to Bignum conversions present in the `json` library and manually convert to string as
+a workaround.
+
 ## 0.1.14.beta
 - Add configurable max retries for requests when running into errors.
 - Add ability to send messages to the dead letter queue if we exhaust all retries and if it is configured.

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -240,7 +240,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     # Plugin level (either per batch or event level metrics). Other request
     # level metrics are handled by the HTTP Client class.
     @multi_receive_statistics = {
-      :total_multi_receive_secs => 0
+      :total_multi_receive_secs => 0,
+      :total_bignum_json_errors => 0
     }
     @plugin_metrics = get_new_metrics
 
@@ -495,6 +496,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
 
       record = l_event.to_hash
 
+      record[:testbig] = 2230504953406034924503240234032
+
       # Create optional threads hash if serverHost is non-nil
       # echee: TODO I don't think threads are necessary.  Too much info?
       # they seem to be a second level of granularity within a logfile
@@ -666,6 +669,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         # Because of the version of jruby logstash works with we don't have the option to just update this away,
         # so if we run into it we convert bignums into strings so we can get the data in at least.
         # This is fixed in JRuby 9.2.7, which includes json 2.2.0
+        @logger.warn("Error serializing events to JSON, likely due to the presence of Bignum values. Converting Bignum values to strings.")
+        @stats_lock.synchronize do
+          @multi_receive_statistics[:total_bignum_json_errors] += 1
+        end
         Scalyr::Common::Util.convert_bignums(scalyr_event)
         event_json = scalyr_event.to_json
         log_json = nil
@@ -760,7 +767,16 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
 
     # We time serialization to get some insight on how long it takes to serialize the request body
     start_time = Time.now.to_f
-    serialized_body = body.to_json
+    begin
+      serialized_body = body.to_json
+    rescue Java::JavaLang::ClassCastException => e
+      @logger.warn("Error serializing events to JSON, likely due to the presence of Bignum values. Converting Bignum values to strings.")
+      @stats_lock.synchronize do
+        @multi_receive_statistics[:total_bignum_json_errors] += 1
+      end
+      Scalyr::Common::Util.convert_bignums(body)
+      serialized_body = body.to_json
+    end
     end_time = Time.now.to_f
     serialization_duration = end_time - start_time
     {

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -76,6 +76,9 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   config :flat_tag_prefix, :validate => :string, :default => 'tag_'
   config :flat_tag_value, :default => 1
 
+  # Whether or not to convert Bigint values to strings to avoid JSON encoding errors
+  config :convert_bignums, :validate => :boolean, :default => false
+
   # Initial interval in seconds between bulk retries. Doubled on each retry up to `retry_max_interval`
   config :retry_initial_interval, :validate => :number, :default => 1
   # How many times to retry sending an event before giving up on it
@@ -588,6 +591,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter)
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time
+      end
+
+      # convert bignums to strings to avoid json errors
+      if @convert_bignums
+        Scalyr::Common::Util.convert_bignums(record)
       end
 
       if should_sample_event_metrics

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -496,8 +496,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
 
       record = l_event.to_hash
 
-      record[:testbig] = 2230504953406034924503240234032
-
       # Create optional threads hash if serverHost is non-nil
       # echee: TODO I don't think threads are necessary.  Too much info?
       # they seem to be a second level of granularity within a logfile

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -241,7 +241,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     # level metrics are handled by the HTTP Client class.
     @multi_receive_statistics = {
       :total_multi_receive_secs => 0,
-      :total_bignum_json_errors => 0
+      :total_bignum_json_errors => 0,
+      :total_successful_json_conversions => 0
     }
     @plugin_metrics = get_new_metrics
 
@@ -646,6 +647,9 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         log_json = nil
         if add_log
           log_json = logs[log_identifier].to_json
+        end
+        @stats_lock.synchronize do
+          @multi_receive_statistics[:total_successful_json_conversions] += 1
         end
       rescue JSON::GeneratorError, Encoding::UndefinedConversionError => e
         @logger.warn "#{e.class}: #{e.message}"

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -52,5 +52,26 @@ def self.truncate(content, max)
   return content
 end
 
+def self.convert_bignums(obj)
+  if obj.respond_to?(:has_key?) and obj.respond_to?(:each)
+    # input object is a hash
+    obj.each do |key, value|
+      obj[key] = convert_bigints(value)
+    end
+
+  elsif obj.respond_to?(:each)
+    # input object is an array or set
+    obj.each_with_index do |value, index|
+      obj[index] = convert_bigints(value)
+    end
+
+  elsif obj.is_a? Bignum
+    return obj.to_s
+
+  else
+    return obj
+  end
+end
+
 end; end; end;
 

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -56,13 +56,13 @@ def self.convert_bignums(obj)
   if obj.respond_to?(:has_key?) and obj.respond_to?(:each)
     # input object is a hash
     obj.each do |key, value|
-      obj[key] = convert_bigints(value)
+      obj[key] = convert_bignums(value)
     end
 
   elsif obj.respond_to?(:each)
     # input object is an array or set
     obj.each_with_index do |value, index|
-      obj[index] = convert_bigints(value)
+      obj[index] = convert_bignums(value)
     end
 
   elsif obj.is_a? Bignum

--- a/spec/benchmarks/bignum_fixing.rb
+++ b/spec/benchmarks/bignum_fixing.rb
@@ -1,0 +1,90 @@
+require 'benchmark'
+require 'quantile'
+
+require_relative '../../lib/scalyr/common/util'
+
+# Micro benchmark which measures how long it takes to find all the Bignums in a record and convert them to strings
+
+ITERATIONS = 500
+
+def rand_str(len)
+  return (0...len).map { (65 + rand(26)).chr }.join
+end
+
+def rand_bignum()
+  return 200004000020304050300 + rand(999999)
+end
+
+def generate_hash(widths)
+  result = {}
+  if widths.empty?
+    return rand_bignum()
+  else
+    widths[0].times do
+      result[rand_str(9)] = generate_hash(widths[1..widths.length])
+    end
+    return result
+  end
+end
+
+def generate_data_array_for_spec(spec)
+  data = []
+  ITERATIONS.times do
+    data << generate_hash(spec)
+  end
+
+  data
+end
+
+def run_benchmark_and_print_results(data, run_benchmark_func)
+  puts ""
+  puts "Using %s total keys in a hash" % [Scalyr::Common::Util.flatten(data[0]).count]
+  puts ""
+
+  result = []
+  ITERATIONS.times do |i|
+    result << Benchmark.measure { run_benchmark_func.(data[0]) }
+  end
+
+  sum = result.inject(nil) { |sum, t| sum.nil? ? sum = t : sum += t }
+  avg = sum / result.size
+
+  Benchmark.bm(7, "sum:", "avg:") do |b|
+    [sum, avg]
+  end
+  puts ""
+end
+
+
+puts "Using %s iterations" % [ITERATIONS]
+puts ""
+
+@value = Quantile::Estimator.new
+@prng = Random.new
+
+def convert_bignums(record)
+  Scalyr::Common::Util.convert_bignums(record)
+end
+
+puts "Util.convert_bignums()"
+puts "==============================="
+
+# Around ~200 keys in a hash
+data = generate_data_array_for_spec([4, 4, 3, 4])
+run_benchmark_and_print_results(data, method(:convert_bignums))
+
+# Around ~200 keys in a hash (single level)
+data = generate_data_array_for_spec([200])
+run_benchmark_and_print_results(data, method(:convert_bignums))
+
+# Around ~512 keys in a hash
+data = generate_data_array_for_spec([8, 4, 4, 4])
+run_benchmark_and_print_results(data, method(:convert_bignums))
+
+# Around ~960 keys in a hash
+data = generate_data_array_for_spec([12, 5, 4, 4])
+run_benchmark_and_print_results(data, method(:convert_bignums))
+
+# Around ~2700 keys in a hash
+data = generate_data_array_for_spec([14, 8, 6, 4])
+run_benchmark_and_print_results(data, method(:convert_bignums))

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -319,10 +319,9 @@ describe LogStash::Outputs::Scalyr do
       end
     end
 
-    context "when configured to convert Bignums" do
+    context "when receiving an event with Bignums" do
       config = {
           'api_write_token' => '1234',
-          'convert_bignums' => true,
       }
       plugin = LogStash::Outputs::Scalyr.new(config)
       it "converts Bignums to strings" do

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -324,19 +324,16 @@ describe LogStash::Outputs::Scalyr do
           'api_write_token' => '1234',
       }
       plugin = LogStash::Outputs::Scalyr.new(config)
-      it "converts Bignums to strings" do
+      it "doesn't throw an error" do
         allow(plugin).to receive(:send_status).and_return(nil)
         plugin.register
         e = LogStash::Event.new
         e.set('bignumber', 2000023030042002050202030320240)
+        allow(plugin.instance_variable_get(:@logger)).to receive(:error)
         result = plugin.build_multi_event_request_array([e])
         body = JSON.parse(result[0][:body])
         expect(body['events'].size).to eq(1)
-        expect(body['events'][0]['attrs']).to eq({
-                                                     "bignumber" => "2000023030042002050202030320240",
-                                                     "parser" => "logstashParser",
-                                                     "serverHost" => "Logstash",
-                                                 })
+        expect(plugin.instance_variable_get(:@logger)).to_not receive(:error)
       end
     end
   end

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -318,5 +318,27 @@ describe LogStash::Outputs::Scalyr do
                                                  })
       end
     end
+
+    context "when configured to convert Bignums" do
+      config = {
+          'api_write_token' => '1234',
+          'convert_bignums' => true,
+      }
+      plugin = LogStash::Outputs::Scalyr.new(config)
+      it "converts Bignums to strings" do
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        e = LogStash::Event.new
+        e.set('bignumber', 2000023030042002050202030320240)
+        result = plugin.build_multi_event_request_array([e])
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(1)
+        expect(body['events'][0]['attrs']).to eq({
+                                                     "bignumber" => "2000023030042002050202030320240",
+                                                     "parser" => "logstashParser",
+                                                     "serverHost" => "Logstash",
+                                                 })
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently when this is configured to be enabled, it will emit warnings:
`warning: constant ::Bignum is deprecated`
I'm making this off by default for that reason, it might be smart to disable these warnings but I'm unsure.