### PR TITLE
Make array flattening optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beta
 
+## TBD
+- Make array flattening optional during nested value flattening with the `flatten_nested_arrays` configuration option.
+
 ## 0.1.17.beta
 - Catch errors relating to Bignum conversions present in the ``json`` library and manually convert to string as
 a workaround.

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -68,7 +68,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # If true, nested values will be flattened (which changes keys to delimiter-separated concatenation of all
   # nested keys).
   config :flatten_nested_values, :validate => :boolean, :default => false
-  config :flatten_nested_values_delimiter, :validate => :string, :default => "_" 
+  config :flatten_nested_values_delimiter, :validate => :string, :default => "_"
+  config :flatten_nested_arrays, :validate => :boolean, :default => true
 
   # If true, the 'tags' field will be flattened into key-values where each key is a tag and each value is set to
   # :flat_tag_value
@@ -611,7 +612,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       # flatten record
       if @flatten_nested_values
         start_time = Time.now.to_f
-        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter)
+        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=flatten_nested_arrays)
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time
       end

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -612,7 +612,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       # flatten record
       if @flatten_nested_values
         start_time = Time.now.to_f
-        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=flatten_nested_arrays)
+        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays)
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time
       end

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -4,7 +4,7 @@ module Scalyr; module Common; module Util;
 # Flattens a hash or array, returning a hash where keys are a delimiter-separated string concatenation of all
 # nested keys.  Returned keys are always strings.  If a non-hash or array is provided, raises TypeError.
 # Please see rspec util_spec.rb for expected behavior.
-def self.flatten(obj, delimiter='_')
+def self.flatten(obj, delimiter='_', flatten_arrays=true)
 
   # base case is input object is not enumerable, in which case simply return it
   if !obj.respond_to?(:each)
@@ -19,8 +19,8 @@ def self.flatten(obj, delimiter='_')
 
     # input object is a hash
     obj.each do |key, value|
-      if value.respond_to?(:each)
-        flatten(value).each do |subkey, subvalue|
+      if (flatten_arrays and value.respond_to?(:each)) or value.respond_to?(:has_key?)
+        flatten(value, delimiter, flatten_arrays).each do |subkey, subvalue|
           result["#{key}#{delimiter}#{subkey}"] = subvalue
         end
       else
@@ -28,18 +28,23 @@ def self.flatten(obj, delimiter='_')
       end
     end
 
-  else
+  elsif flatten_arrays
 
     # input object is an array or set
     obj.each_with_index do |value, index|
       if value.respond_to?(:each)
-        flatten(value).each do |subkey, subvalue|
+        flatten(value, delimiter, flatten_arrays).each do |subkey, subvalue|
           result["#{index}#{delimiter}#{subkey}"] = subvalue
         end
       else
         result["#{index}"] = value
       end
     end
+
+  else
+
+    result = obj
+
   end
 
   return result

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -273,9 +273,41 @@ describe LogStash::Outputs::Scalyr do
         expect(body['events'].size).to eq(3)
         expect(body['events'][2]['attrs']).to eq({
                                                      "nested.a" => 1,
-                                                     "nested.b_0" => 3,
-                                                     "nested.b_1" => 4,
-                                                     "nested.b_2" => 5,
+                                                     "nested.b.0" => 3,
+                                                     "nested.b.1" => 4,
+                                                     "nested.b.2" => 5,
+                                                     'seq' => 3,
+                                                     'source_file' => 'my file 3',
+                                                     'source_host' => 'my host 3',
+                                                     'serverHost' => 'Logstash',
+                                                     "tag_prefix_t1" => "true",
+                                                     "tag_prefix_t2" => "true",
+                                                     "tag_prefix_t3" => "true",
+                                                     "parser" => "logstashParser",
+                                                 })
+      end
+    end
+
+    context "when configured to flatten values with custom delimiter, no array flattening" do
+      config = {
+          'api_write_token' => '1234',
+          'flatten_tags' => true,
+          'flat_tag_value' => 'true',
+          'flat_tag_prefix' => 'tag_prefix_',
+          'flatten_nested_values' => true,  # this converts into string 'true'
+          'flatten_nested_arrays' => false,
+          'flatten_nested_values_delimiter' => ".",
+      }
+      plugin = LogStash::Outputs::Scalyr.new(config)
+      it "flattens nested values with a period" do
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        result = plugin.build_multi_event_request_array(sample_events)
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(3)
+        expect(body['events'][2]['attrs']).to eq({
+                                                     "nested.a" => 1,
+                                                     "nested.b" => [3, 4, 5],
                                                      'seq' => 3,
                                                      'source_file' => 'my file 3',
                                                      'source_host' => 'my host 3',

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -132,6 +132,70 @@ describe Scalyr::Common::Util do
     expect(Scalyr::Common::Util.flatten(din)).to eq(dout)
   end
 
+  it "flattens a single-level array, no array flattening" do
+    din = [1, 2, 3]
+    dout = [1, 2, 3]
+    expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
+  it "flattens a multi-level array, no array flattening" do
+    din = ['a', 'b', ['c', ['d', 'e', 'f'], 'g'], 'h', 'i']
+    dout = ['a', 'b', ['c', ['d', 'e', 'f'], 'g'], 'h', 'i']
+    expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
+  it "flattens a hash that contains an array, no array flattening" do
+    din = {
+        'a' => 1,
+        'c' => [100, 200, 300]
+    }
+    dout = {
+        'a' => 1,
+        'c' => [100, 200, 300]
+    }
+    expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
+  it "flattens a hash that contains an array that contains a hash, no array flattening" do
+    din = {
+        'a' => 1,
+        'c' => [
+            100,
+            {'d' => 1000, 'e' => 2000},
+            300
+        ]
+    }
+    dout = {
+        'a' => 1,
+        'c' => [
+            100,
+            {'d' => 1000, 'e' => 2000},
+            300
+        ]
+    }
+    expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
+  it "flattens a hash that contains an array that contains a hash that contains an array, no array flattening" do
+    din = {
+        'a' => 1,
+        'c' => [
+            100,
+            {'d' => 1000, 'e' => 2000, 'f' => [4, 5, 6]},
+            300
+        ]
+    }
+    dout = {
+        'a' => 1,
+        'c' => [
+            100,
+            {'d' => 1000, 'e' => 2000, 'f' => [4, 5, 6]},
+            300
+        ]
+    }
+    expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
   it "accepts custom delimiters" do
     din = {
         'a' => 1,


### PR DESCRIPTION
Adds a `flatten_nested_arrays` option that defaults to `true`, controls how we handle arrays during `flatten_nested_values` work. If false we just leave them as is.

Also fixes an issue where any nested flattening below the first level would have the default delimiter, not sure if anyone is relying on that bug but I doubt it.