### PR TITLE
Reintroduce bug with flattening delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beta
 
+## TBD
+- Undo a change to nested value flattening functionality to keep existing formatting.
+
 ## 0.1.18.beta
 - Add metrics for successfully sent and failed logstash events, and retries.
 - Make array flattening optional during nested value flattening with the `flatten_nested_arrays` configuration option.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Beta
 
 ## TBD
-- Undo a change to nested value flattening functionality to keep existing formatting.
+- Undo a change to nested value flattening functionality to keep existing formatting. This change can be re-enabled
+by setting the `fix_deep_flattening_delimiters` configuration option to true.
 
 ## 0.1.18.beta
 - Add metrics for successfully sent and failed logstash events, and retries.

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -70,6 +70,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   config :flatten_nested_values, :validate => :boolean, :default => false
   config :flatten_nested_values_delimiter, :validate => :string, :default => "_"
   config :flatten_nested_arrays, :validate => :boolean, :default => true
+  config :fix_deep_flattening_delimiters, :validate => :boolean, :default => false
 
   # If true, the 'tags' field will be flattened into key-values where each key is a tag and each value is set to
   # :flat_tag_value
@@ -632,7 +633,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       # flatten record
       if @flatten_nested_values
         start_time = Time.now.to_f
-        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays)
+        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays, fix_deep_flattening_delimiters=@fix_deep_flattening_delimiters)
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time
       end

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -6,7 +6,7 @@ module Scalyr; module Common; module Util;
 # Please see rspec util_spec.rb for expected behavior.
 # Includes a known bug where defined delimiter will not be used for nesting levels past the first, this is kept
 # because some queries and dashboards already rely on the broken functionality.
-def self.flatten(obj, delimiter='_', flatten_arrays=true)
+def self.flatten(obj, delimiter='_', flatten_arrays=true, fix_deep_flattening_delimiters=false)
 
   # base case is input object is not enumerable, in which case simply return it
   if !obj.respond_to?(:each)
@@ -22,7 +22,7 @@ def self.flatten(obj, delimiter='_', flatten_arrays=true)
     # input object is a hash
     obj.each do |key, value|
       if (flatten_arrays and value.respond_to?(:each)) or value.respond_to?(:has_key?)
-        flatten(value, '_', flatten_arrays).each do |subkey, subvalue|
+        flatten(value, fix_deep_flattening_delimiters ? delimiter : '_', flatten_arrays).each do |subkey, subvalue|
           result["#{key}#{delimiter}#{subkey}"] = subvalue
         end
       else
@@ -35,7 +35,7 @@ def self.flatten(obj, delimiter='_', flatten_arrays=true)
     # input object is an array or set
     obj.each_with_index do |value, index|
       if value.respond_to?(:each)
-        flatten(value, '_', flatten_arrays).each do |subkey, subvalue|
+        flatten(value, fix_deep_flattening_delimiters ? delimiter : '_', flatten_arrays).each do |subkey, subvalue|
           result["#{index}#{delimiter}#{subkey}"] = subvalue
         end
       else

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -4,6 +4,8 @@ module Scalyr; module Common; module Util;
 # Flattens a hash or array, returning a hash where keys are a delimiter-separated string concatenation of all
 # nested keys.  Returned keys are always strings.  If a non-hash or array is provided, raises TypeError.
 # Please see rspec util_spec.rb for expected behavior.
+# Includes a known bug where defined delimiter will not be used for nesting levels past the first, this is kept
+# because some queries and dashboards already rely on the broken functionality.
 def self.flatten(obj, delimiter='_', flatten_arrays=true)
 
   # base case is input object is not enumerable, in which case simply return it
@@ -20,7 +22,7 @@ def self.flatten(obj, delimiter='_', flatten_arrays=true)
     # input object is a hash
     obj.each do |key, value|
       if (flatten_arrays and value.respond_to?(:each)) or value.respond_to?(:has_key?)
-        flatten(value, delimiter, flatten_arrays).each do |subkey, subvalue|
+        flatten(value, '_', flatten_arrays).each do |subkey, subvalue|
           result["#{key}#{delimiter}#{subkey}"] = subvalue
         end
       else
@@ -33,7 +35,7 @@ def self.flatten(obj, delimiter='_', flatten_arrays=true)
     # input object is an array or set
     obj.each_with_index do |value, index|
       if value.respond_to?(:each)
-        flatten(value, delimiter, flatten_arrays).each do |subkey, subvalue|
+        flatten(value, '_', flatten_arrays).each do |subkey, subvalue|
           result["#{index}#{delimiter}#{subkey}"] = subvalue
         end
       else

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -288,6 +288,40 @@ describe LogStash::Outputs::Scalyr do
       end
     end
 
+    context "when configured to flatten values with custom delimiter and deep delimiter fix" do
+      config = {
+          'api_write_token' => '1234',
+          'flatten_tags' => true,
+          'flat_tag_value' => 'true',
+          'flat_tag_prefix' => 'tag_prefix_',
+          'flatten_nested_values' => true,  # this converts into string 'true'
+          'flatten_nested_values_delimiter' => ".",
+          'fix_deep_flattening_delimiters' => true,
+      }
+      plugin = LogStash::Outputs::Scalyr.new(config)
+      it "flattens nested values with a period" do
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        result = plugin.build_multi_event_request_array(sample_events)
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(3)
+        expect(body['events'][2]['attrs']).to eq({
+                                                     "nested.a" => 1,
+                                                     "nested.b.0" => 3,
+                                                     "nested.b.1" => 4,
+                                                     "nested.b.2" => 5,
+                                                     'seq' => 3,
+                                                     'source_file' => 'my file 3',
+                                                     'source_host' => 'my host 3',
+                                                     'serverHost' => 'Logstash',
+                                                     "tag_prefix_t1" => "true",
+                                                     "tag_prefix_t2" => "true",
+                                                     "tag_prefix_t3" => "true",
+                                                     "parser" => "logstashParser",
+                                                 })
+      end
+    end
+
     context "when configured to flatten values with custom delimiter, no array flattening" do
       config = {
           'api_write_token' => '1234',

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -273,9 +273,9 @@ describe LogStash::Outputs::Scalyr do
         expect(body['events'].size).to eq(3)
         expect(body['events'][2]['attrs']).to eq({
                                                      "nested.a" => 1,
-                                                     "nested.b.0" => 3,
-                                                     "nested.b.1" => 4,
-                                                     "nested.b.2" => 5,
+                                                     "nested.b_0" => 3,
+                                                     "nested.b_1" => 4,
+                                                     "nested.b_2" => 5,
                                                      'seq' => 3,
                                                      'source_file' => 'my file 3',
                                                      'source_host' => 'my host 3',

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -212,6 +212,42 @@ describe Scalyr::Common::Util do
     expect(Scalyr::Common::Util.flatten(din, ':')).to eq(dout)
   end
 
+  it "accepts custom delimiters with greater depth" do
+    din = {
+        'a' => 1,
+        'b' => {
+            'c' => {
+              'e' => 100
+            },
+            'd' => 200,
+        }
+    }
+    dout = {
+        'a' => 1,
+        'b:c_e' => 100,
+        'b:d' => 200,
+    }
+    expect(Scalyr::Common::Util.flatten(din, ':')).to eq(dout)
+  end
+
+  it "accepts custom delimiters with greater depth and deep delimiters fix" do
+    din = {
+        'a' => 1,
+        'b' => {
+            'c' => {
+              'e' => 100
+            },
+            'd' => 200,
+        }
+    }
+    dout = {
+        'a' => 1,
+        'b:c:e' => 100,
+        'b:d' => 200,
+    }
+    expect(Scalyr::Common::Util.flatten(din, ':', true, true)).to eq(dout)
+  end
+
   it "stringifies non-string keys" do
     din = {
         'a' => 1,


### PR DESCRIPTION
There was a bug fix in the last version that fixed an issue where custom delimiters used in flattening would only affect the first layer of nesting. Unfortunately there was already dashboards and queries that relied on this broken functionality. As a quick fix this PR will reintroduce the bug.