### PR TITLE
Change flattening code to be iterative and not recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beta
 
+## 0.1.20.beta
+- Rewrite flattening function to no longer be recursive, to help avoid maxing out the stack.
+- Added a configurable value `flattening_max_key_count` to create a limit on how large of a record we can flatten.
+It limits the maximum amount of keys we can have in the final flattened record. Defaults to unlimited.
+
 ## 0.1.19.beta
 - Undo a change to nested value flattening functionality to keep existing formatting. This change can be re-enabled
 by setting the `fix_deep_flattening_delimiters` configuration option to true.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can view documentation for this plugin [on the Scalyr website](https://app.s
 # Quick start
 
 1. Build the gem, run `gem build logstash-output-scalyr.gemspec` 
-2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.19.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
+2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.20.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
 3. Configure the output plugin (e.g. add it to a pipeline .conf)
 4. Restart Logstash 
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -71,6 +71,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   config :flatten_nested_values_delimiter, :validate => :string, :default => "_"
   config :flatten_nested_arrays, :validate => :boolean, :default => true
   config :fix_deep_flattening_delimiters, :validate => :boolean, :default => false
+  config :flattening_max_key_count, :validate => :number, :default => -1
 
   # If true, the 'tags' field will be flattened into key-values where each key is a tag and each value is set to
   # :flat_tag_value
@@ -633,7 +634,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       # flatten record
       if @flatten_nested_values
         start_time = Time.now.to_f
-        record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays, fix_deep_flattening_delimiters=@fix_deep_flattening_delimiters)
+        begin
+          record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays, fix_deep_flattening_delimiters=@fix_deep_flattening_delimiters, max_key_count=@flattening_max_key_count)
+        rescue RuntimeError => e
+          @logger.warn("Error while flattening record", :error_message => e.message)
+        end
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time
       end

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -636,8 +636,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         start_time = Time.now.to_f
         begin
           record = Scalyr::Common::Util.flatten(record, delimiter=@flatten_nested_values_delimiter, flatten_arrays=@flatten_nested_arrays, fix_deep_flattening_delimiters=@fix_deep_flattening_delimiters, max_key_count=@flattening_max_key_count)
-        rescue RuntimeError => e
-          @logger.warn("Error while flattening record", :error_message => e.message)
+        rescue Scalyr::Common::Util::MaxKeyCountError => e
+          @logger.warn("Error while flattening record", :error_message => e.message, :sample_keys => e.sample_keys)
         end
         end_time = Time.now.to_f
         flatten_nested_values_duration = end_time - start_time

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -6,7 +6,7 @@ module Scalyr; module Common; module Util;
 # Please see rspec util_spec.rb for expected behavior.
 # Includes a known bug where defined delimiter will not be used for nesting levels past the first, this is kept
 # because some queries and dashboards already rely on the broken functionality.
-def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flattening_delimiters=false)
+def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flattening_delimiters=false, max_key_count=-1)
 
   # base case is input object is not enumerable, in which case simply return it
   if !hash_obj.respond_to?(:each)
@@ -65,6 +65,10 @@ def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flatteni
         end
       end
       result[result_key] = obj
+
+      if max_key_count > -1 and result.keys.count > max_key_count
+        raise RuntimeError.new("Resulting flattened object will contain more keys than the configured flattening_max_key_count of #{max_key_count}")
+      end
 
       throw_away = key_list.pop
       until key_list_width.empty? or key_list_width[-1] > 1

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -1,5 +1,13 @@
 module Scalyr; module Common; module Util;
 
+class MaxKeyCountError < StandardError
+  attr_reader :message, :sample_keys
+
+  def initialize(message, sample_keys)
+    @message = message
+    @sample_keys = sample_keys
+  end
+end
 
 # Flattens a hash or array, returning a hash where keys are a delimiter-separated string concatenation of all
 # nested keys.  Returned keys are always strings.  If a non-hash or array is provided, raises TypeError.
@@ -67,7 +75,10 @@ def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flatteni
       result[result_key] = obj
 
       if max_key_count > -1 and result.keys.count > max_key_count
-        raise RuntimeError.new("Resulting flattened object will contain more keys than the configured flattening_max_key_count of #{max_key_count}")
+        raise MaxKeyCountError.new(
+          "Resulting flattened object will contain more keys than the configured flattening_max_key_count of #{max_key_count}",
+          result.keys[0..6]
+        )
       end
 
       throw_away = key_list.pop

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.1.19.beta"
+PLUGIN_VERSION = "v0.1.20.beta"

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.19.beta'
+  s.version         = '0.1.20.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -435,6 +435,7 @@ describe LogStash::Outputs::Scalyr do
         expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error while flattening record",
           {
             :error_message=>"Resulting flattened object will contain more keys than the configured flattening_max_key_count of 3",
+            :sample_keys=>["serverHost", "parser", "tags_2", "tags_1"]
           }
         ).exactly(3).times
       end

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -283,4 +283,23 @@ describe Scalyr::Common::Util do
   it "raises exception if a non-dict is provided" do
     expect {Scalyr::Common::Util.flatten(1)}.to raise_error(TypeError)
   end
+
+  it "flattens a hash 5000 layers deep" do
+    din = {
+        'a' => {},
+    }
+    hash = din
+    for i in 0...4999
+      hash = hash["a"]
+      hash["a"] = {}
+      if i == 4998
+        hash["a"] = "b"
+      end
+    end
+
+    dout = {
+        'a' + "_a" * 4999 => "b",
+    }
+    expect(Scalyr::Common::Util.flatten(din, '_')).to eq(dout)
+  end
 end


### PR DESCRIPTION
Rewrite of the hash/array flattening util code to be iterative, inspired by running into issues related to very deeply nested objects.

I suspect there are multiple ways to make this code nicer, but I was having difficulty keeping these stacks in my head as is (apparently my brain has less memory than what we give this plugin by quite a lot).