### PR TITLE
Fix issue with iterative flattening due to empty collections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beta
 
+## 0.1.21.beta
+- Fix issue with iterative flattening function when dealing with empty collections.
+
 ## 0.1.20.beta
 - Rewrite flattening function to no longer be recursive, to help avoid maxing out the stack.
 - Added a configurable value `flattening_max_key_count` to create a limit on how large of a record we can flatten.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.19.beta)
+    logstash-output-scalyr (0.1.21.beta)
       ffi (>= 1.9.18)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can view documentation for this plugin [on the Scalyr website](https://app.s
 # Quick start
 
 1. Build the gem, run `gem build logstash-output-scalyr.gemspec` 
-2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.20.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
+2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.21.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
 3. Configure the output plugin (e.g. add it to a pipeline .conf)
 4. Restart Logstash 
 

--- a/lib/scalyr/common/util.rb
+++ b/lib/scalyr/common/util.rb
@@ -42,7 +42,7 @@ def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flatteni
     key_list << key_stack.pop
 
     # Case when object is a hash
-    if obj.respond_to?(:has_key?)
+    if obj.respond_to?(:has_key?) and obj.keys.count > 0
       key_list_width << obj.keys.count
       obj.each do |key, value|
         key_stack << key
@@ -50,12 +50,12 @@ def self.flatten(hash_obj, delimiter='_', flatten_arrays=true, fix_deep_flatteni
       end
 
     # Case when object is an array we intend to flatten
-    elsif flatten_arrays and obj.respond_to?(:each)
-      key_list_width << obj.count
-      obj.each_with_index do |value, index|
-        key_stack << index
-        stack << value
-      end
+    elsif flatten_arrays and obj.respond_to?(:each) and obj.count > 0
+        key_list_width << obj.count
+        obj.each_with_index do |value, index|
+          key_stack << index
+          stack << value
+        end
 
     else
       result_key = ""

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.1.20.beta"
+PLUGIN_VERSION = "v0.1.21.beta"

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.20.beta'
+  s.version         = '0.1.21.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -68,6 +68,7 @@ LARGE_OBJECT_OUT = {
   "task_FooProps_10_TcpPorts_4" => 55,
   "task_FooProps_10_TcpPorts_5" => 8000,
   "task_FooProps_10_TcpPorts_6" => 8080,
+  "task_FooProps_10_UdpPorts" => [],
   "task_Id" => 1211111181111111400,
   "task_Ips_0" => "127.0.0.1",
   "task_Ips_1" => "127.0.0.2",
@@ -321,6 +322,63 @@ describe Scalyr::Common::Util do
 
   it "flattens large hash correctly not flatten arrays" do
     expect(Scalyr::Common::Util.flatten(LARGE_OBJECT_IN, "_", flatten_arrays=false)).to eq(LARGE_OBJECT_OUT_NO_FLATTEN_ARRAYS)
+  end
+
+  it "flattens hash containing empty list correctly" do
+    obj_in = {
+      "abc" => 123,
+      "array" => [],
+      "hash" => {
+        "value" => "abc123",
+        "another_array" => []
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "array" => [],
+      "hash_value" => "abc123",
+      "hash_another_array" => []
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
+  end
+
+  it "flattens hash containing empty list correctly not flatten arrays" do
+    obj_in = {
+      "abc" => 123,
+      "array" => [],
+      "hash" => {
+        "value" => "abc123",
+        "another_array" => []
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "array" => [],
+      "hash_value" => "abc123",
+      "hash_another_array" => []
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=false)).to eq(obj_out)
+  end
+
+  it "flattens hash containing empty hash correctly" do
+    obj_in = {
+      "abc" => 123,
+      "empty_hash" => {},
+      "hash" => {
+        "value" => "abc123",
+        "another_hash" => {}
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "empty_hash" => {},
+      "hash_value" => "abc123",
+      "hash_another_hash" => {}
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
   end
 
   it "accepts custom delimiters" do

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -1,6 +1,90 @@
 # encoding: utf-8
 require "scalyr/common/util"
 
+LARGE_OBJECT_IN = {
+  "level": "info",
+  "ts": "2020-08-11T02:26:17.078Z",
+  "caller": "api/foo:480",
+  "msg": "assign active task foobar",
+  "accountId": 12345,
+  "cycleId": 6789,
+  "uuid": "a405a4b58810e3aaa078f751bd32baa8b60aaad1",
+  "task": {
+    "Id": 1211111181111111400,
+    "TaskTypes": [
+      4,
+      11,
+      10,
+      12,
+      17,
+      14
+    ],
+    "Ips": [
+      "127.0.0.1",
+      "127.0.0.2",
+      "127.0.0.3",
+      "127.0.0.4",
+      "127.0.0.5",
+    ],
+    "FooProps": {
+      "10": {
+        "TcpPorts": [
+          22,
+          23,
+          25,
+          80,
+          55,
+          8000,
+          8080,
+        ],
+        "UdpPorts": []
+      }
+    },
+    "Subnet": "127.0.0.0/24"
+  },
+  "relevance": 0,
+  "scannerIp": "10.0.0.2",
+  "gatewayIp": "10.0.0.1",
+  "gatewayMac": "fa:fa:fa:fa",
+  "wired": true,
+  "elapsed": 74.86664
+}
+
+LARGE_OBJECT_OUT = {
+  "accountId" => 12345,
+  "caller" => "api/foo:480",
+  "cycleId" => 6789,
+  "elapsed" => 74.86664,
+  "gatewayIp" => "10.0.0.1",
+  "gatewayMac" => "fa:fa:fa:fa",
+  "level" => "info",
+  "msg" => "assign active task foobar",
+  "relevance" => 0,
+  "scannerIp" => "10.0.0.2",
+  "task_FooProps_10_TcpPorts_0" => 22,
+  "task_FooProps_10_TcpPorts_1" => 23,
+  "task_FooProps_10_TcpPorts_2" => 25,
+  "task_FooProps_10_TcpPorts_3" => 80,
+  "task_FooProps_10_TcpPorts_4" => 55,
+  "task_FooProps_10_TcpPorts_5" => 8000,
+  "task_FooProps_10_TcpPorts_6" => 8080,
+  "task_Id" => 1211111181111111400,
+  "task_Ips_0" => "127.0.0.1",
+  "task_Ips_1" => "127.0.0.2",
+  "task_Ips_2" => "127.0.0.3",
+  "task_Ips_3" => "127.0.0.4",
+  "task_Ips_4" => "127.0.0.5",
+  "task_Subnet" => "127.0.0.0/24",
+  "task_TaskTypes_0" => 4,
+  "task_TaskTypes_1" => 11,
+  "task_TaskTypes_2" => 10,
+  "task_TaskTypes_3" => 12,
+  "task_TaskTypes_4" => 17,
+  "task_TaskTypes_5" => 14,
+  "ts" => "2020-08-11T02:26:17.078Z",
+  "uuid" => "a405a4b58810e3aaa078f751bd32baa8b60aaad1",
+  "wired" => true,
+}
 
 describe Scalyr::Common::Util do
   it "does not flatten an already-flat dict" do
@@ -208,6 +292,10 @@ describe Scalyr::Common::Util do
         ]
     }
     expect(Scalyr::Common::Util.flatten(din, "_", flatten_arrays=false)).to eq(dout)
+  end
+
+  it "flattens large hash correctly" do
+    expect(Scalyr::Common::Util.flatten(LARGE_OBJECT_IN, "_", flatten_arrays=true)).to eq(LARGE_OBJECT_OUT)
   end
 
   it "accepts custom delimiters" do

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -86,6 +86,27 @@ LARGE_OBJECT_OUT = {
   "wired" => true,
 }
 
+LARGE_OBJECT_OUT_NO_FLATTEN_ARRAYS = {
+  "accountId" => 12345,
+  "caller" => "api/foo:480",
+  "cycleId" => 6789,
+  "elapsed" => 74.86664,
+  "gatewayIp" => "10.0.0.1",
+  "gatewayMac" => "fa:fa:fa:fa",
+  "level" => "info",
+  "msg" => "assign active task foobar",
+  "relevance" => 0,
+  "scannerIp" => "10.0.0.2",
+  "task_FooProps_10_TcpPorts" => [22, 23, 25, 80, 55, 8000, 8080],
+  "task_FooProps_10_UdpPorts" => [],
+  "task_Id" => 1211111181111111400,
+  "task_Ips" => ["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4", "127.0.0.5"],
+  "task_Subnet" => "127.0.0.0/24",
+  "task_TaskTypes" => [4, 11, 10, 12, 17, 14],
+  "ts" => "2020-08-11T02:26:17.078Z",
+  "uuid" => "a405a4b58810e3aaa078f751bd32baa8b60aaad1",
+  "wired" => true,
+}
 describe Scalyr::Common::Util do
   it "does not flatten an already-flat dict" do
     din = {
@@ -296,6 +317,10 @@ describe Scalyr::Common::Util do
 
   it "flattens large hash correctly" do
     expect(Scalyr::Common::Util.flatten(LARGE_OBJECT_IN, "_", flatten_arrays=true)).to eq(LARGE_OBJECT_OUT)
+  end
+
+  it "flattens large hash correctly not flatten arrays" do
+    expect(Scalyr::Common::Util.flatten(LARGE_OBJECT_IN, "_", flatten_arrays=false)).to eq(LARGE_OBJECT_OUT_NO_FLATTEN_ARRAYS)
   end
 
   it "accepts custom delimiters" do

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -381,6 +381,55 @@ describe Scalyr::Common::Util do
     expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
   end
 
+  it "flattens hash containing nested bignum correctly" do
+    obj_in = {
+      "abc" => 123,
+      "hash" => {
+        "value" => 2000023030042002050202030320240
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "hash_value" => 2000023030042002050202030320240
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
+  end
+
+  it "flattens hash containing nested boolean correctly" do
+    obj_in = {
+      "abc" => 123,
+      "hash" => {
+        "value" => true,
+        "otherValue" => false
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "hash_value" => true,
+      "hash_otherValue" => false
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
+  end
+
+  it "flattens hash containing nested float correctly" do
+    obj_in = {
+      "abc" => 123,
+      "hash" => {
+        "value" => 321.12345,
+        "otherValue" => 0.0000003
+      }
+    }
+
+    obj_out = {
+      "abc" => 123,
+      "hash_value" => 321.12345,
+      "hash_otherValue" => 0.0000003
+    }
+    expect(Scalyr::Common::Util.flatten(obj_in, "_", flatten_arrays=true)).to eq(obj_out)
+  end
+
   it "accepts custom delimiters" do
     din = {
         'a' => 1,


### PR DESCRIPTION
The iterative flattening code incorrectly handled cases of nested empty collections, resulting in the final key names being all mixed up. This solution causes empty collections to show up as final values which is different from the earlier recursive code, but not necessarily negative.

This PR includes the changes to the Changelog and version for the release that will contain this fix.