### PR TITLE
Add new metric for tracking the duration of "build_multi_event_request_array" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Beta
 
+## 0.1.22.beta
+- Add new plugin metric for tracking the duration of ``build_multi_event_request_array`` method.
+
 ## 0.1.21.beta
 - Fix issue with iterative flattening function when dealing with empty collections.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.22.beta
 - Add new plugin metric for tracking the duration of ``build_multi_event_request_array`` method.
+- Update internal dependencies (``manticore``) to latest stable version.
 
 ## 0.1.21.beta
 - Fix issue with iterative flattening function when dealing with empty collections.

--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ end
 
 gem 'pry'
 gem 'pry-nav'
-gem 'quantile'
-gem 'manticore', platform: :jruby
+gem 'quantile', '~> 0.2.1'
+gem 'manticore', '~> 0.7.1', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ DEPENDENCIES
   manticore (~> 0.7.1)
   pry
   pry-nav
-  quantile
+  quantile (~> 0.2.1)
   webmock
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       rspec (~> 3.0)
       rspec-wait
       stud (>= 0.0.20)
-    manticore (0.6.4-java)
+    manticore (0.7.1-java)
       openssl_pkcs8_pure
     method_source (0.8.2)
     minitar (0.5.4)
@@ -154,7 +154,7 @@ PLATFORMS
 DEPENDENCIES
   logstash-devutils
   logstash-output-scalyr!
-  manticore
+  manticore (~> 0.7.1)
   pry
   pry-nav
   quantile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.1.21.beta)
+    logstash-output-scalyr (0.1.22.beta)
       ffi (>= 1.9.18)
       logstash-codec-plain
       logstash-core-plugin-api (>= 1.60, <= 2.99)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can view documentation for this plugin [on the Scalyr website](https://app.s
 # Quick start
 
 1. Build the gem, run `gem build logstash-output-scalyr.gemspec` 
-2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.21.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
+2. Install the gem into a Logstash installation, run `/usr/share/logstash/bin/logstash-plugin install logstash-output-scalyr-0.1.22.beta.gem` or follow the latest official instructions on working with plugins from Logstash.
 3. Configure the output plugin (e.g. add it to a pipeline .conf)
 4. Restart Logstash 
 

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.1.21.beta"
+PLUGIN_VERSION = "v0.1.22.beta"

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.21.beta'
+  s.version         = '0.1.22.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -7,6 +7,12 @@ require "json"
 require 'webmock/rspec'
 WebMock.allow_net_connect!
 
+RSpec.configure do |rspec|
+  rspec.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+end
+
 describe LogStash::Outputs::Scalyr do
   let(:sample_events) {
     events = []

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -64,7 +64,7 @@ describe LogStash::Outputs::Scalyr do
                 {
                   :error_class=>"Manticore::UnknownException",
                   :batch_num=>1,
-                  :message=>"Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty",
+                  :message=>"java.lang.RuntimeException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty",
                   :payload_size=>781,
                   :record_count=>3,
                   :total_batches=>1,
@@ -90,7 +90,7 @@ describe LogStash::Outputs::Scalyr do
                 {
                   :error_class=>"Manticore::UnknownException",
                   :batch_num=>1,
-                  :message=>"Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty",
+                  :message=>"java.lang.RuntimeException: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty",
                   :payload_size=>781,
                   :record_count=>3,
                   :total_batches=>1,

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -80,6 +80,7 @@ describe LogStash::Outputs::Scalyr do
         plugin1.instance_variable_set(:@client_session, mock_client_session)
         plugin1.instance_variable_set(:@session_id, "some_session_id")
         plugin1.instance_variable_set(:@plugin_metrics, {
+          :build_multi_duration_secs => Quantile::Estimator.new,
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,
@@ -87,10 +88,11 @@ describe LogStash::Outputs::Scalyr do
           :batches_per_multi_receive => Quantile::Estimator.new
         })
         plugin1.instance_variable_get(:@plugin_metrics)[:multi_receive_duration_secs].observe(1)
+        plugin1.instance_variable_get(:@plugin_metrics)[:build_multi_duration_secs].observe(1)
         plugin1.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
 
         status_event = plugin1.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 build_multi_duration_secs_p50=1 build_multi_duration_secs_p90=1 build_multi_duration_secs_p99=1 multi_receive_duration_p50=1 multi_receive_duration_p90=1 multi_receive_duration_p99=1 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0")
       end
 
       it "returns and sends correct status event on send_stats on initial and subsequent send" do
@@ -106,6 +108,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.instance_variable_set(:@client_session, mock_client_session)
         # Setup one quantile calculation to make sure at least one of them calculates as expected
         plugin.instance_variable_set(:@plugin_metrics, {
+          :build_multi_duration_secs => Quantile::Estimator.new,
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,
@@ -119,12 +122,13 @@ describe LogStash::Outputs::Scalyr do
 
         plugin.instance_variable_set(:@multi_receive_statistics, {:total_multi_receive_secs => 0})
         status_event = plugin.send_status
-        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
+        expect(status_event[:attrs]["message"]).to eq("plugin_status: total_requests_sent=20 total_requests_failed=10 total_request_bytes_sent=100 total_compressed_request_bytes_sent=50 total_response_bytes_received=100 total_request_latency_secs=100 total_serialization_duration_secs=100.5000 total_compression_duration_secs=10.2000 compression_type=deflate compression_level=9 total_multi_receive_secs=0 build_multi_duration_secs_p50=0 build_multi_duration_secs_p90=0 build_multi_duration_secs_p99=0 multi_receive_duration_p50=10 multi_receive_duration_p90=18 multi_receive_duration_p99=19 multi_receive_event_count_p50=0 multi_receive_event_count_p90=0 multi_receive_event_count_p99=0 event_attributes_count_p50=0 event_attributes_count_p90=0 event_attributes_count_p99=0 batches_per_multi_receive_p50=0 batches_per_multi_receive_p90=0 batches_per_multi_receive_p99=0 flatten_values_duration_secs_p50=0 flatten_values_duration_secs_p90=0 flatten_values_duration_secs_p99=0")
       end
 
       it "send_stats is called when events list is empty, but otherwise is noop" do
         quantile_estimator = Quantile::Estimator.new
         plugin.instance_variable_set(:@plugin_metrics, {
+          :build_multi_duration_secs => Quantile::Estimator.new,
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count => Quantile::Estimator.new,
@@ -149,6 +153,7 @@ describe LogStash::Outputs::Scalyr do
         mock_client_session = MockClientSession.new
         quantile_estimator = Quantile::Estimator.new
         plugin2.instance_variable_set(:@plugin_metrics, {
+          :build_multi_duration_secs => Quantile::Estimator.new,
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count => Quantile::Estimator.new,
@@ -174,6 +179,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.instance_variable_set(:@last_status_transmit_time, 100)
         plugin.instance_variable_set(:@client_session, mock_client_session)
         plugin.instance_variable_set(:@plugin_metrics, {
+          :build_multi_duration_secs => Quantile::Estimator.new,
           :multi_receive_duration_secs => Quantile::Estimator.new,
           :multi_receive_event_count => Quantile::Estimator.new,
           :event_attributes_count =>  Quantile::Estimator.new,


### PR DESCRIPTION
This PR adds new quantile metric for tracking the duration of ``build_multi_event_request_array`` method.

Every now and then we see relatively large ``multi_receive_duration_secs`` metric where other metrics are seemingly normal and low (batch not being split into multiple Scalyr requests and serialization and duration metrics being relatively flow).

This may provides us with a better insight if in cases like that, majority of the time is indeed spent in that method.