### PR TITLE
Add support for additional JSON serialization library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,7 @@ jobs: # a collection of steps
       - run:
           name: Run Micro Benchmarks
           command: |
+            gem install jrjackson
             gem install quantile
             echo "Flattening and serialization util results:"
             echo ""
@@ -149,6 +150,12 @@ jobs: # a collection of steps
             echo ""
             echo "Metrics recording results:"
             ruby spec/benchmarks/metrics_overhead.rb
+            echo ""
+            echo "Bignum converting results:"
+            ruby spec/benchmarks/bignum_fixing.rb
+            echo ""
+            echo "json serialization:"
+            ruby spec/benchmarks/json_serialization.rb
             echo ""
 
   # We run micro benchmarks against cRuby just for reference purposes since plugins always run
@@ -164,6 +171,7 @@ jobs: # a collection of steps
       - run:
           name: Run Micro Benchmarks
           command: |
+            gem install jrjackson
             gem install quantile
             echo "Flattening and serialization util results:"
             echo ""
@@ -174,6 +182,9 @@ jobs: # a collection of steps
             echo ""
             echo "Bignum converting results:"
             ruby spec/benchmarks/bignum_fixing.rb
+            echo ""
+            echo "json serialization:"
+            ruby spec/benchmarks/json_serialization.rb
             echo ""
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,6 @@ jobs: # a collection of steps
       - run:
           name: Run Micro Benchmarks
           command: |
-            gem install jrjackson
             gem install quantile
             echo "Flattening and serialization util results:"
             echo ""
@@ -182,10 +181,6 @@ jobs: # a collection of steps
             echo ""
             echo "Bignum converting results:"
             ruby spec/benchmarks/bignum_fixing.rb
-            echo ""
-            echo "json serialization:"
-            ruby spec/benchmarks/json_serialization.rb
-            echo ""
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Beta
 
+## 0.1.26.beta
+- Add support for new ``json_library`` config option. Valid values are ``stdlib`` (default) are ``jrjackson``. The later may offer 2-4x faster JSON serialization.
+
+
 ## 0.1.23.beta
 - Add testing support for disabling estimation of serialized event size for each event in the batch.
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 group :test do
   gem "webmock"
+  gem "jrjackson"
 end
 
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,10 @@ end
 
 group :test do
   gem "webmock"
-  gem "jrjackson"
 end
 
 gem 'pry'
 gem 'pry-nav'
 gem 'quantile', '~> 0.2.1'
 gem 'manticore', '~> 0.7.1', platform: :jruby
+gem 'jrjackson', '~> 0.4.14', platform: :jruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,7 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
+  jrjackson
   logstash-devutils
   logstash-output-scalyr!
   manticore (~> 0.7.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     i18n (0.6.9)
     insist (1.0.0)
     jar-dependencies (0.4.0)
-    jrjackson (0.4.8-java)
+    jrjackson (0.4.14-java)
     jruby-openssl (0.9.19-java)
     kramdown (1.14.0)
     logstash-codec-plain (3.0.6)
@@ -152,7 +152,7 @@ PLATFORMS
   universal-java-11
 
 DEPENDENCIES
-  jrjackson
+  jrjackson (~> 0.4.14)
   logstash-devutils
   logstash-output-scalyr!
   manticore (~> 0.7.1)

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,2 +1,2 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.1.25.beta"
+PLUGIN_VERSION = "v0.1.26.beta"

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -18,11 +18,12 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  #
   s.add_runtime_dependency 'net-http-persistent'
   s.add_runtime_dependency 'logstash-core-plugin-api', '>= 1.60', '<= 2.99'
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'quantile'
+  s.add_runtime_dependency 'jrjackson'
+  s.add_runtime_dependency 'manticore'
   s.add_runtime_dependency 'ffi', '>= 1.9.18'
   s.add_runtime_dependency 'rbzip2', '0.3.0'
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.1.25.beta'
+  s.version         = '0.1.26.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/benchmarks/flattening_and_serialization.rb
+++ b/spec/benchmarks/flattening_and_serialization.rb
@@ -2,37 +2,13 @@ require 'benchmark'
 require 'json'
 
 require_relative '../../lib/scalyr/common/util'
+require_relative './util'
 
 # NOTE: When using jRuby using multiple iterations with the same dataset doesn't make
 # sense since it will just use JITed version of the code which will be very fast. If we
 # wanted to accurately measure using multiple iterations we would need te different
 # input data for each iteration.
 ITERATIONS = 500
-
-def rand_str(len)
-  return (0...len).map { (65 + rand(26)).chr }.join
-end
-
-def generate_hash(widths)
-  result = {}
-  if widths.empty?
-    return rand_str(20)
-  else
-    widths[0].times do
-      result[rand_str(9)] = generate_hash(widths[1..widths.length])
-    end
-    return result
-  end
-end
-
-def generate_data_array_for_spec(spec)
-  data = []
-  ITERATIONS.times do
-    data << generate_hash(spec)
-  end
-
-  data
-end
 
 def run_benchmark_and_print_results(data, run_benchmark_func)
   puts ""
@@ -69,7 +45,6 @@ DATASETS = {
   :keys_960 => generate_data_array_for_spec([12, 5, 4, 4]),
   :keys_2700 => generate_data_array_for_spec([14, 8, 6, 4])
 }
-
 
 puts "Using %s iterations" % [ITERATIONS]
 puts ""

--- a/spec/benchmarks/json_serialization.rb
+++ b/spec/benchmarks/json_serialization.rb
@@ -1,0 +1,85 @@
+require 'benchmark'
+require 'json'
+require 'jrjackson'
+
+require_relative '../../lib/scalyr/common/util'
+require_relative './util'
+
+ITERATIONS = 500
+
+def json_serialize_data_native(data)
+  data.to_json
+end
+
+def json_serialize_data_jrjackson(data)
+  JrJackson::Json.dump(data)
+end
+
+DATASETS = {
+  :keys_50 => generate_data_array_for_spec([3, 3, 3, 2]),
+  :keys_200 => generate_data_array_for_spec([4, 4, 3, 4]),
+  :keys_200_flat => generate_data_array_for_spec([200]),
+  :keys_512 => generate_data_array_for_spec([8, 4, 4, 4]),
+  :keys_960 => generate_data_array_for_spec([12, 5, 4, 4]),
+  :keys_2700 => generate_data_array_for_spec([14, 8, 6, 4])
+}
+
+def run_benchmark_and_print_results(data, run_benchmark_func)
+  puts ""
+  puts "Using %s total keys in a hash" % [Scalyr::Common::Util.flatten(data[0]).count]
+  puts ""
+
+  result = []
+  ITERATIONS.times do |i|
+    result << Benchmark.measure { run_benchmark_func.(data[0]) }
+  end
+
+  sum = result.inject(nil) { |sum, t| sum.nil? ? sum = t : sum += t }
+  avg = sum / result.size
+
+  Benchmark.bm(7, "sum:", "avg:") do |b|
+    [sum, avg]
+  end
+  puts ""
+end
+
+puts "Using %s iterations" % [ITERATIONS]
+puts ""
+
+puts "native"
+puts "==============================="
+
+# Around ~50 keys in a hash
+data = DATASETS[:keys_50]
+run_benchmark_and_print_results(data, method(:json_serialize_data_native))
+
+# Around ~200 keys in a hash
+data = DATASETS[:keys_200]
+run_benchmark_and_print_results(data, method(:json_serialize_data_native))
+
+# Around ~200 keys in a hash (single level)
+data = DATASETS[:keys_200_flat]
+run_benchmark_and_print_results(data, method(:json_serialize_data_native))
+
+# Around ~2700 keys in a hash
+data = DATASETS[:keys_2700]
+run_benchmark_and_print_results(data, method(:json_serialize_data_native))
+
+puts "jrjackson"
+puts "==============================="
+
+# Around ~50 keys in a hash
+data = DATASETS[:keys_50]
+run_benchmark_and_print_results(data, method(:json_serialize_data_jrjackson))
+
+# Around ~200 keys in a hash
+data = DATASETS[:keys_200]
+run_benchmark_and_print_results(data, method(:json_serialize_data_jrjackson))
+
+# Around ~200 keys in a hash (single level)
+data = DATASETS[:keys_200_flat]
+run_benchmark_and_print_results(data, method(:json_serialize_data_jrjackson))
+
+# Around ~2700 keys in a hash
+data = DATASETS[:keys_2700]
+run_benchmark_and_print_results(data, method(:json_serialize_data_jrjackson))

--- a/spec/benchmarks/util.rb
+++ b/spec/benchmarks/util.rb
@@ -1,0 +1,24 @@
+def rand_str(len)
+  return (0...len).map { (65 + rand(26)).chr }.join
+end
+
+def generate_hash(widths)
+  result = {}
+  if widths.empty?
+    return rand_str(20)
+  else
+    widths[0].times do
+      result[rand_str(9)] = generate_hash(widths[1..widths.length])
+    end
+    return result
+  end
+end
+
+def generate_data_array_for_spec(spec)
+  data = []
+  ITERATIONS.times do
+    data << generate_hash(spec)
+  end
+
+  data
+end


### PR DESCRIPTION
This PR adds new ``json_library`` config option.

With this config option user can control which library to use for JSON serialization. Valid options are ``stdlib`` and ``jrjackson``.

For now, we default to ``stdlib`` (aka same as before).

Per micro-benchmarks data, ``jrjackson`` can be 2-5x faster than stdlib library - https://app.circleci.com/pipelines/github/scalyr/logstash-output-scalyr/449/workflows/9374afd5-2a00-4fef-8be8-6c0d1f9dc2fd/jobs/1491/parallel-runs/0/steps/0-103.

In the future after more battle testing we may want to consider and switch default value to ``jrjackson`` if no issues are encountered.