### PR TITLE
Use json 1.8.6 in tests, same as the json used when running Logstash

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 
 group :test do
   gem "webmock"
+  gem 'json', '1.8.6'
 end
 
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ end
 
 group :test do
   gem "webmock"
+
+  # Require the specific version of `json` used in logstash while testing
   gem 'json', '1.8.6'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
     jar-dependencies (0.4.0)
     jrjackson (0.4.14-java)
     jruby-openssl (0.9.19-java)
+    json (1.8.6-java)
     kramdown (1.14.0)
     logstash-codec-plain (3.0.6)
       logstash-core-plugin-api (>= 1.60, <= 2.99)
@@ -155,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   jrjackson (~> 0.4.14)
+  json (= 1.8.6)
   logstash-devutils
   logstash-output-scalyr!
   manticore (~> 0.7.1)
@@ -164,4 +166,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.18
+   2.2.27

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -5,6 +5,11 @@ require "logstash/codecs/plain"
 require "logstash/event"
 require "json"
 require 'webmock/rspec'
+
+# Require the specific version of `json` used in logstash
+gem 'json', '1.8.6'
+require 'json'
+
 WebMock.allow_net_connect!
 
 RSpec.configure do |rspec|

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -6,6 +6,10 @@ require "logstash/event"
 require "json"
 require "quantile"
 
+# Require the specific version of `json` used in logstash
+gem 'json', '1.8.6'
+require 'json'
+
 NODE_HOSTNAME = Socket.gethostname
 
 class MockClientSession
@@ -833,6 +837,7 @@ describe LogStash::Outputs::Scalyr do
         result = plugin.build_multi_event_request_array([e])
         body = JSON.parse(result[0][:body])
         expect(body['events'].size).to eq(1)
+        expect(body['events'][0]['attrs']['bignumber']).to be_a_kind_of(String)
         expect(plugin.instance_variable_get(:@logger)).to_not receive(:error)
       end
     end

--- a/spec/scalyr/common/util_spec.rb
+++ b/spec/scalyr/common/util_spec.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 require "scalyr/common/util"
 
+# Require the specific version of `json` used in logstash
+gem 'json', '1.8.6'
+require 'json'
+
 LARGE_OBJECT_IN = {
   "level": "info",
   "ts": "2020-08-11T02:26:17.078Z",


### PR DESCRIPTION
For whatever reason when running a plugin in logstash, the included `json` gem is on version `1.8.6`, well behind the most recent version. This version also still includes the bug where Bignum's are not converted correctly. As a result we want to use this version of `json` when running our tests to confirm our handling of this bug is correct (until we have server side fixes and start using a new json library).