### PR TITLE
Better handle various errors related to the invalid scalyr server URL in the register() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@
   ``scalyr_server`` configuration option value and other fatal server errors (e.g. invalid
   hostname).
 - On plugin init / register we now perform connectivity check and verify that we can talk to
-  Scalyr API and that the API key is valid. This ensures that the plugin doesn't start and
-  start consuming events until we can successfully perform a connectivity check which means
-  we can't end up in situation when we could potentially drop some events in case of an invalid
-  API token or similar when reaching retry limit and DLQ disabled. If you want to disable this
-  check on register, you can set ``perform_connectivity_check`` config option to ``false``.
+  Scalyr API and validate that the API key is valid. This ensures that the plugin doesn't start and
+  start consuming events until we can successfully perform a connectivity check. This means
+  we can't end up in situation when we could potentially drop some events to the ground in case of
+  an invalid API key or similar when reaching retry limit and DLQ disabled. If you want to disable
+  this check on register, you can set ``perform_connectivity_check`` config option to ``false``.
 
 ## 0.2.0.beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
   Scalyr API and that the API key is valid. This ensures that the plugin doesn't start and
   start consuming events until we can successfully perform a connectivity check which means
   we can't end up in situation when we could potentially drop some events in case of an invalid
-  API token or similar when reaching retry limit and DLQ disabled.
+  API token or similar when reaching retry limit and DLQ disabled. If you want to disable this
+  check on register, you can set ``perform_connectivity_check`` config option to ``false``.
 
 ## 0.2.0.beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beta
 
+## 0.2.1.beta
+
+- Update plugin to throw more user-friendly error on invalid URL for ``scalyr_server``
+  configuration option value.
+
 ## 0.2.0.beta
 
 - Fix a bug and correctly handle ``serverHost`` event level attribute. Now if an event contains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## 0.2.1.beta
 
-- Update plugin to throw more user-friendly error on invalid URL for ``scalyr_server``
-  configuration option value.
+- Update plugin to fail fast on register and throw more user-friendly error on invalid URL for
+  ``scalyr_server`` configuration option value and other fatal server errors (e.g. invalid
+  hostname).
 
 ## 0.2.0.beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Update plugin to fail fast on register and throw more user-friendly error on invalid URL for
   ``scalyr_server`` configuration option value and other fatal server errors (e.g. invalid
   hostname).
+- On plugin init / register we now perform connectivity check and verify that we can talk to
+  Scalyr API and that the API key is valid. This ensures that the plugin doesn't start and
+  start consuming events until we can successfully perform a connectivity check which means
+  we can't end up in situation when we could potentially drop some events in case of an invalid
+  API token or similar when reaching retry limit and DLQ disabled.
 
 ## 0.2.0.beta
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    logstash-output-scalyr (0.2.0)
+    logstash-output-scalyr (0.2.1.beta)
       ffi (>= 1.9.18)
       jrjackson
       logstash-codec-plain

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -378,7 +378,10 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     begin
       @client_session.send_ping(body)
     rescue Scalyr::Common::Client::ClientError, Manticore::ResolutionFailure => e
-      if not e.message.nil? and e.message.include?("nodename nor servname provided")
+      puts "---1"
+      puts e.message
+      if not e.message.nil? and (e.message.include?("nodename nor servname provided") or
+          e.message.downcase.include?("name or service not know"))
         raise LogStash::ConfigurationError,
                     format("Received error when trying to communicate with Scalyr API. This likely means that " \
                            "the configured value for 'scalyr_server' config option is invalid. Original error: %s",
@@ -397,6 +400,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       end
 
     rescue => e
+      puts "---2"
+      puts e.message
       @logger.warn("Received non-fatal error during connectivity check", :error => e.message)
     end
   end

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -378,8 +378,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     begin
       @client_session.send_ping(body)
     rescue Scalyr::Common::Client::ClientError, Manticore::ResolutionFailure => e
-      puts "---1"
-      puts e.message
       if not e.message.nil? and (e.message.include?("nodename nor servname provided") or
           e.message.downcase.include?("name or service not know"))
         raise LogStash::ConfigurationError,
@@ -400,8 +398,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       end
 
     rescue => e
-      puts "---2"
-      puts e.message
       @logger.warn("Received non-fatal error during connectivity check", :error => e.message)
     end
   end

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -355,7 +355,11 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
 
       # For now, we consider rest of the errors non fatal and just log them and don't propagate
       # them and fail register
-      @logger.error("Received error when trying to send initial status request to Scalyr", :error => e.message)
+      @logger.error("Received error when trying to send initial status request to Scalyr",
+                    :error => e.message)
+    rescue => e
+      @logger.error("Received non-fatal error when trying to send initial status request to " \
+                    "Scalyr", :error => e.message)
     ensure
       initial_send_status_client_session.close
     end

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -1032,7 +1032,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # Finally, note that there could be multiple instances of this plugin (one per worker), in which case each worker
   # thread sends their own status updates.  This is intentional so that we know how much data each worker thread is
   # uploading to Scalyr over time.
-  def send_status(client_session = nil, propagate_error = false)
+  def send_status(client_session = nil)
     client_session = @client_session if client_session.nil?
 
     status_event = {
@@ -1088,10 +1088,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             :error_message => e.message,
             :error_class => e.class.name
           )
-        end
-
-        if propagate_error
-          raise e
         end
 
         return

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -219,7 +219,15 @@ class ClientSession
     end
   end
 
+  # Send "ping" request to the API. This is mostly used to test the connecting with Scalyr API
+  # and verify that the API key is valid.
+  def send_ping(body)
+    post_body, post_headers, compression_duration = prepare_post_object @add_events_uri.path, body
+    response = client.send(:post, @add_events_uri, body: post_body, headers: post_headers)
+    handle_response(response)
 
+    response
+  end
 
   # Upload data to Scalyr. Assumes that the body size complies with Scalyr limits
   def post_add_events(body, is_status, body_serialization_duration = 0)

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-PLUGIN_VERSION = "v0.2.0"
+PLUGIN_VERSION = "v0.2.1.beta"
 
 # Special event level attribute name which can be used for setting event level serverHost attribute
 EVENT_LEVEL_SERVER_HOST_ATTRIBUTE_NAME = '__origServerHost'

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.2.0'
+  s.version         = '0.2.1.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -32,7 +32,7 @@ describe LogStash::Outputs::Scalyr do
       context "with default SSL configuration" do
         it "throws a ServerError due to fake api key" do
               plugin = LogStash::Outputs::Scalyr.new({
-                'api_write_token' => '1235',
+                'api_write_token' => '1234',
                 'perform_connectivity_check' => false,
               })
               plugin.register

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -31,7 +31,10 @@ describe LogStash::Outputs::Scalyr do
   describe "#ssl_tests" do
       context "with default SSL configuration" do
         it "throws a ServerError due to fake api key" do
-              plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234'})
+              plugin = LogStash::Outputs::Scalyr.new({
+                'api_write_token' => '1235',
+                'perform_connectivity_check' => false,
+              })
               plugin.register
               plugin.instance_variable_set(:@running, false)
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
@@ -55,7 +58,12 @@ describe LogStash::Outputs::Scalyr do
 
       context "when pointing at a location without any valid certs and not using builtin" do
         it "throws an SSLError" do
-              plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+              plugin = LogStash::Outputs::Scalyr.new({
+                'api_write_token' => '1234',
+                'perform_connectivity_check' => false,
+                'ssl_ca_bundle_path' => '/fakepath/nocerts',
+                'append_builtin_cert' => false,
+              })
               plugin.register
               plugin.instance_variable_set(:@running, false)
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
@@ -81,7 +89,11 @@ describe LogStash::Outputs::Scalyr do
           `sudo mv #{OpenSSL::X509::DEFAULT_CERT_DIR} /tmp/system_certs`
 
           begin
-              plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'append_builtin_cert' => false})
+              plugin = LogStash::Outputs::Scalyr.new({
+                'api_write_token' => '1234',
+                'perform_connectivity_check' => false,
+                'append_builtin_cert' => false,
+              })
               plugin.register
               plugin.instance_variable_set(:@running, false)
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
@@ -120,7 +132,11 @@ describe LogStash::Outputs::Scalyr do
           `echo "#{etc_hosts_entry}" | sudo tee -a /etc/hosts`
 
           begin
-              plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'scalyr_server' => 'https://invalid.mitm.should.fail.test.agent.scalyr.com:443'})
+              plugin = LogStash::Outputs::Scalyr.new({
+                'api_write_token' => '1234',
+                'perform_connectivity_check' => false,
+                'scalyr_server' => 'https://invalid.mitm.should.fail.test.agent.scalyr.com:443',
+              })
               plugin.register
               plugin.instance_variable_set(:@running, false)
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
@@ -147,7 +163,13 @@ describe LogStash::Outputs::Scalyr do
 
       context "when an error occurs with retries at 5" do
         it "exits after 5 retries and emits a log" do
-              plugin = LogStash::Outputs::Scalyr.new({'retry_initial_interval' => 0.1, 'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+              plugin = LogStash::Outputs::Scalyr.new({
+                'api_write_token' => '1234',
+                'perform_connectivity_check' => false,
+                'retry_initial_interval' => 0.1,
+                'ssl_ca_bundle_path' => '/fakepath/nocerts',
+                'append_builtin_cert' => false
+              })
               plugin.register
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
               plugin.multi_receive(sample_events)
@@ -163,7 +185,12 @@ describe LogStash::Outputs::Scalyr do
         stub_request(:post, "https://agent.scalyr.com/addEvents").
           to_return(status: 503, body: "stubbed response", headers: {})
 
-        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+        plugin = LogStash::Outputs::Scalyr.new({
+          'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
+          'ssl_ca_bundle_path' => '/fakepath/nocerts',
+          'append_builtin_cert' => false
+        })
         plugin.register
         plugin.instance_variable_set(:@running, false)
 
@@ -191,7 +218,12 @@ describe LogStash::Outputs::Scalyr do
         stub_request(:post, "https://agent.scalyr.com/addEvents").
           to_return(status: 500, body: "stubbed response", headers: {})
 
-        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+        plugin = LogStash::Outputs::Scalyr.new({
+          'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
+          'ssl_ca_bundle_path' => '/fakepath/nocerts',
+          'append_builtin_cert' => false
+        })
         plugin.register
         plugin.instance_variable_set(:@running, false)
 
@@ -219,7 +251,12 @@ describe LogStash::Outputs::Scalyr do
         stub_request(:post, "https://agent.scalyr.com/addEvents").
           to_return(status: 500, body: "0123456789" * 52, headers: {})
 
-        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+        plugin = LogStash::Outputs::Scalyr.new({
+            'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
+            'ssl_ca_bundle_path' => '/fakepath/nocerts',
+            'append_builtin_cert' => false
+        })
         plugin.register
         plugin.instance_variable_set(:@running, false)
 
@@ -248,7 +285,12 @@ describe LogStash::Outputs::Scalyr do
         stub_request(:post, "https://agent.scalyr.com/addEvents").
           to_return(status: 500, body: "stubbed response", headers: {})
 
-        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'ssl_ca_bundle_path' => '/fakepath/nocerts', 'append_builtin_cert' => false})
+        plugin = LogStash::Outputs::Scalyr.new({
+            'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
+            'ssl_ca_bundle_path' => '/fakepath/nocerts',
+            'append_builtin_cert' => false
+        })
         plugin.register
         plugin.instance_variable_set(:@running, false)
         plugin.instance_variable_set('@dlq_writer', dlq_writer)

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -971,7 +971,6 @@ describe LogStash::Outputs::Scalyr do
 
     context "scalyr_server config option handling and connectivity check" do
       it "doesn't throw an error on valid url" do
-        puts "c"
         config = {
             'api_write_token' => '1234',
             'perform_connectivity_check' => false,

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -791,6 +791,7 @@ describe LogStash::Outputs::Scalyr do
       it "no serverHost defined, event level serverHost defined via non-default serverhost_field - event level value should be used" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'attr1' => 'val1'},
             'use_hostname_for_serverhost' => false,
             'serverhost_field' => 'custom_server_host',

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -941,5 +941,49 @@ describe LogStash::Outputs::Scalyr do
         expect(body['events'].size).to eq(1)
       end
     end
+
+    context "scalyr_server config option handling" do
+      it "doesn't throw an error on valid url" do
+        puts "c"
+        config = {
+            'api_write_token' => '1234',
+            'scalyr_server' => 'https://agent.scalyr.com'
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        plugin.register
+
+        config = {
+            'api_write_token' => '1234',
+            'scalyr_server' => 'https://eu.scalyr.com'
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        plugin.register
+      end
+
+      it "throws on invalid URL" do
+        config = {
+            'api_write_token' => '1234',
+            'scalyr_server' => 'agent.scalyr.com'
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /is not a valid URL/)
+
+        config = {
+            'api_write_token' => '1234',
+            'scalyr_server' => 'eu.scalyr.com'
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /is not a valid URL/)
+      end
+
+      it "throws on invalid hostname" do
+        config = {
+            'api_write_token' => '1234',
+            'scalyr_server' => 'https://agent.foo.invalid.scalyr.com'
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /Received error when trying to communicate/)
+      end
+    end
   end
 end

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -57,6 +57,7 @@ describe LogStash::Outputs::Scalyr do
     context "test get_stats and send_status" do
       plugin = LogStash::Outputs::Scalyr.new({
                                                      'api_write_token' => '1234',
+                                                     'perform_connectivity_check' => false,
                                                      'serverhost_field' => 'source_host',
                                                      'log_constants' => ['tags'],
                                                      'flatten_nested_values' => true,
@@ -73,6 +74,7 @@ describe LogStash::Outputs::Scalyr do
       it "it doesnt include flatten metrics if flattening is disabled" do
         plugin1 = LogStash::Outputs::Scalyr.new({
                                                      'api_write_token' => '1234',
+                                                     'perform_connectivity_check' => false,
                                                      'serverhost_field' => 'source_host',
                                                      'log_constants' => ['tags'],
                                                      'flatten_nested_values' => false,
@@ -147,6 +149,7 @@ describe LogStash::Outputs::Scalyr do
       it "send_stats is not called when events list is empty and report_status_for_empty_batches is false" do
         plugin2 = LogStash::Outputs::Scalyr.new({
                                                      'api_write_token' => '1234',
+                                                     'perform_connectivity_check' => false,
                                                      'serverhost_field' => 'source_host',
                                                      'log_constants' => ['tags'],
                                                      'flatten_nested_values' => false,
@@ -202,6 +205,7 @@ describe LogStash::Outputs::Scalyr do
       it "creates logfile from serverHost" do
         plugin = LogStash::Outputs::Scalyr.new({
                                                    'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
                                                    'serverhost_field' => 'source_host',
                                                    'log_constants' => ['tags'],
                                                })
@@ -219,7 +223,7 @@ describe LogStash::Outputs::Scalyr do
 
     context "when serverhost_field is missing" do
       it "does not contain log file" do
-        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234'})
+        plugin = LogStash::Outputs::Scalyr.new({'api_write_token' => '1234', 'perform_connectivity_check' => false})
         allow(plugin).to receive(:send_status).and_return(nil)
         plugin.register
         result = plugin.build_multi_event_request_array(sample_events)
@@ -233,6 +237,7 @@ describe LogStash::Outputs::Scalyr do
       it "creates logfile from serverHost" do
         plugin = LogStash::Outputs::Scalyr.new({
                                                    'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
                                                    'serverhost_field' => 'source_host',
                                                })
         allow(plugin).to receive(:send_status).and_return(nil)
@@ -250,6 +255,7 @@ describe LogStash::Outputs::Scalyr do
       it "does not contain log file" do
         plugin = LogStash::Outputs::Scalyr.new({
                                                    'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
                                                    'serverhost_field' => 'source_host',
                                                    'logfile_field' => 'source_file',
                                                })
@@ -267,6 +273,7 @@ describe LogStash::Outputs::Scalyr do
     context "when configured to flatten values with custom delimiter" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
           'flatten_tags' => true,
           'flat_tag_value' => 'true',
           'flat_tag_prefix' => 'tag_prefix_',
@@ -299,6 +306,7 @@ describe LogStash::Outputs::Scalyr do
     context "when configured to flatten values with custom delimiter and deep delimiter fix" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
           'flatten_tags' => true,
           'flat_tag_value' => 'true',
           'flat_tag_prefix' => 'tag_prefix_',
@@ -332,6 +340,7 @@ describe LogStash::Outputs::Scalyr do
     context "when configured to flatten values with custom delimiter, no array flattening" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
           'flatten_tags' => true,
           'flat_tag_value' => 'true',
           'flat_tag_prefix' => 'tag_prefix_',
@@ -363,6 +372,7 @@ describe LogStash::Outputs::Scalyr do
     context "when configured to flatten values and tags" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
           'flatten_tags' => true,
           'flat_tag_value' => 'true',
           'flat_tag_prefix' => 'tag_prefix_',
@@ -395,6 +405,7 @@ describe LogStash::Outputs::Scalyr do
       it "estimate_each_event_size is true explicit (default) batch split into 3 scalyr requests" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'flatten_tags' => true,
             'flat_tag_value' => 'true',
             'flat_tag_prefix' => 'tag_prefix_',
@@ -435,6 +446,7 @@ describe LogStash::Outputs::Scalyr do
       it "estimate_each_event_size is true implicit (default) batch split into 3 scalyr requests" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'flatten_tags' => true,
             'flat_tag_value' => 'true',
             'flat_tag_prefix' => 'tag_prefix_',
@@ -474,6 +486,7 @@ describe LogStash::Outputs::Scalyr do
       it "estimate_each_event_size is false batch not split into multiple scalyr requests" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'flatten_tags' => true,
             'flat_tag_value' => 'true',
             'flat_tag_prefix' => 'tag_prefix_',
@@ -509,6 +522,7 @@ describe LogStash::Outputs::Scalyr do
     context "when not configured to flatten values and tags" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
       }
       plugin = LogStash::Outputs::Scalyr.new(config)
       it "does not flatten" do
@@ -531,6 +545,7 @@ describe LogStash::Outputs::Scalyr do
     context "when configured to flatten with max keys configured to 3" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
           'flatten_nested_values' => true,  # this converts into string 'true'
           'flattening_max_key_count' => 3,
       }
@@ -563,6 +578,7 @@ describe LogStash::Outputs::Scalyr do
       it "no serverHost defined in server_attributes, no serverHost defined on event level - should use node hostname as the default session level value" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
 
@@ -581,6 +597,7 @@ describe LogStash::Outputs::Scalyr do
       it "serverHost defined in server_attributes, nothing defined on event level - server_attributes value should be used" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'serverHost' => 'fooHost'}
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -600,6 +617,7 @@ describe LogStash::Outputs::Scalyr do
       it "serverHost defined in server_attributes (explicitly defined), event level serverHost defined - event level value should be used" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'serverHost' => 'fooHost', 'attr1' => 'val1'}
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -656,6 +674,7 @@ describe LogStash::Outputs::Scalyr do
       it "serverHost defined in server_attributes (defined via node hostname), event level serverHost defined - event level value should be used" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'attr1' => 'val1'}
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -715,6 +734,7 @@ describe LogStash::Outputs::Scalyr do
       it "serverHost defined in server_attributes (explicitly defined), event level serverHost defined - event level value should be used and server level one for events without server host" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'serverHost' => 'top-level-session-host', 'attr1' => 'val1'}
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -767,6 +787,7 @@ describe LogStash::Outputs::Scalyr do
       it "no serverHost defined, event level serverHost defined - event level value should be used" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'server_attributes' => {'attr1' => 'val1'},
             'use_hostname_for_serverhost' => false
         }
@@ -822,6 +843,7 @@ describe LogStash::Outputs::Scalyr do
     context "when receiving an event with Bignums" do
       config = {
           'api_write_token' => '1234',
+          'perform_connectivity_check' => false,
       }
       plugin = LogStash::Outputs::Scalyr.new(config)
       it "doesn't throw an error" do
@@ -841,6 +863,7 @@ describe LogStash::Outputs::Scalyr do
       it "host attribute removed by default" do
        config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
 
@@ -866,6 +889,7 @@ describe LogStash::Outputs::Scalyr do
       it "host attribute not removed if config option set" do
        config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'remove_host_attribute_from_events' => false,
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -894,6 +918,7 @@ describe LogStash::Outputs::Scalyr do
       it "stdlib (implicit)" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
 
@@ -910,6 +935,7 @@ describe LogStash::Outputs::Scalyr do
       it "stdlib (explicit)" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'json_library' => 'stdlib'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -927,6 +953,7 @@ describe LogStash::Outputs::Scalyr do
       it "jrjackson" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'json_library' => 'jrjackson'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -942,11 +969,12 @@ describe LogStash::Outputs::Scalyr do
       end
     end
 
-    context "scalyr_server config option handling" do
+    context "scalyr_server config option handling and connectivity check" do
       it "doesn't throw an error on valid url" do
         puts "c"
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'scalyr_server' => 'https://agent.scalyr.com'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -954,6 +982,7 @@ describe LogStash::Outputs::Scalyr do
 
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'scalyr_server' => 'https://eu.scalyr.com'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -963,6 +992,7 @@ describe LogStash::Outputs::Scalyr do
       it "throws on invalid URL" do
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'scalyr_server' => 'agent.scalyr.com'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -970,6 +1000,7 @@ describe LogStash::Outputs::Scalyr do
 
         config = {
             'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
             'scalyr_server' => 'eu.scalyr.com'
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
@@ -979,10 +1010,23 @@ describe LogStash::Outputs::Scalyr do
       it "throws on invalid hostname" do
         config = {
             'api_write_token' => '1234',
-            'scalyr_server' => 'https://agent.foo.invalid.scalyr.com'
+            'perform_connectivity_check' => false,
+            'scalyr_server' => 'https://agent.invalid.foo.scalyr.com',
+            'perform_connectivity_check' => true
         }
         plugin = LogStash::Outputs::Scalyr.new(config)
         expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /Received error when trying to communicate/)
+      end
+
+      it "throws on invalid api key" do
+        config = {
+            'api_write_token' => '1234',
+            'perform_connectivity_check' => false,
+            'scalyr_server' => 'https://agent.scalyr.com',
+            'perform_connectivity_check' => true
+        }
+        plugin = LogStash::Outputs::Scalyr.new(config)
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /Received 401 from Scalyr API during/)
       end
     end
   end


### PR DESCRIPTION
Small change to the plugin ``register()`` method to handle various errors related to invalid scalyr_server config option value and similar in a more user-friendly manner.

Previously in scenarios like that, plugin would partially mask errors in situations like that which would make it hard to determine the root cause aka why the plugin is not working.

We now throw if the provided error is invalid (e.g. invalid URI string or if we can't resolve the hostname or similar).