### PR TITLE
Increase default number of maximum retries on failure from 5 to 15, change non-fatal error log level from error to warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## 0.2.3
 
 - Increase default number of maximum retry attempts on failure from `5` to `15`.
+- Change "Unexpected error occurred while uploading to Scalyr (will backoff-retry)" message to
+  be logged under WARNING and not ERROR log level. This error is not fatal and simply indicates
+  client will retry a failed request. We use WARNING and not INFO so we still have visibility into
+  those messages (since most deployments have log level set to WARNING or above).
 
 ## 0.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Beta
 
+## 0.2.3
+
+- Increase default number of maximum retry attempts on failure from `5` to `15`.
+
 ## 0.2.2
 
 - No longer vendor dependencies in the gem. This gem used to vendor a vulnerable log4j version

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -505,7 +505,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             exc_commonly_retried = true
           else
             # all other failed uploads should be warning
-            @logger.warn(rmessage, exc_data)
+            @logger.warn(message, exc_data)
             exc_commonly_retried = false
           end
           retry if @running and exc_retries < @max_retries

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -105,6 +105,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # Initial interval in seconds between bulk retries. Doubled on each retry up to `retry_max_interval`
   config :retry_initial_interval, :validate => :number, :default => 1
   # How many times to retry sending an event before giving up on it
+  # This will result in a total of around 12 minutes of retrying / sleeping with a default value
+  # for retry_max_interval
   config :max_retries, :validate => :number, :default => 15
   # Whether or not to send messages that failed to send a max_retries amount of times to the DLQ or just drop them
   config :send_to_dlq, :validate => :boolean, :default => true

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -105,7 +105,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # Initial interval in seconds between bulk retries. Doubled on each retry up to `retry_max_interval`
   config :retry_initial_interval, :validate => :number, :default => 1
   # How many times to retry sending an event before giving up on it
-  config :max_retries, :validate => :number, :default => 5
+  config :max_retries, :validate => :number, :default => 15
   # Whether or not to send messages that failed to send a max_retries amount of times to the DLQ or just drop them
   config :send_to_dlq, :validate => :boolean, :default => true
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -504,8 +504,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             @logger.debug(message, exc_data)
             exc_commonly_retried = true
           else
-            # all other failed uploads should be errors
-            @logger.error(message, exc_data)
+            # all other failed uploads should be warning
+            @logger.warn(rmessage, exc_data)
             exc_commonly_retried = false
           end
           retry if @running and exc_retries < @max_retries

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -166,7 +166,7 @@ describe LogStash::Outputs::Scalyr do
         end
       end
 
-      context "when an error occurs with retries at 5" do
+      context "when an error occurs with retries at 15" do
         it "exits after 5 retries and emits a log" do
               plugin = LogStash::Outputs::Scalyr.new({
                 'api_write_token' => '1234',
@@ -178,7 +178,7 @@ describe LogStash::Outputs::Scalyr do
               plugin.register
               allow(plugin.instance_variable_get(:@logger)).to receive(:error)
               plugin.multi_receive(sample_events)
-              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Failed to send 3 events after 5 tries.", anything
+              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Failed to send 3 events after 15 tries.", anything
               )
         end
       end

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -42,9 +42,9 @@ describe LogStash::Outputs::Scalyr do
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
-              allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+              allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
               plugin.multi_receive(sample_events)
-              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+              expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :error_class=>"Scalyr::Common::Client::ServerError",
                   :batch_num=>1,
@@ -71,9 +71,9 @@ describe LogStash::Outputs::Scalyr do
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
-              allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+              allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
               plugin.multi_receive(sample_events)
-              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+              expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :error_class=>"Manticore::UnknownException",
                   :batch_num=>1,
@@ -101,9 +101,9 @@ describe LogStash::Outputs::Scalyr do
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
-              allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+              allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
               plugin.multi_receive(sample_events)
-              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+              expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :error_class=>"Manticore::UnknownException",
                   :batch_num=>1,
@@ -144,9 +144,9 @@ describe LogStash::Outputs::Scalyr do
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
-              allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+              allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
               plugin.multi_receive(sample_events)
-              expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+              expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
                 {
                   :error_class=>"Manticore::UnknownException",
                   :batch_num=>1,
@@ -232,9 +232,9 @@ describe LogStash::Outputs::Scalyr do
         plugin.register
         plugin.instance_variable_set(:@running, false)
 
-        allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+        allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
         plugin.multi_receive(sample_events)
-        expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+        expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
           {
             :error_class=>"Scalyr::Common::Client::ServerError",
             :batch_num=>1,
@@ -265,9 +265,9 @@ describe LogStash::Outputs::Scalyr do
         plugin.register
         plugin.instance_variable_set(:@running, false)
 
-        allow(plugin.instance_variable_get(:@logger)).to receive(:error)
+        allow(plugin.instance_variable_get(:@logger)).to receive(:warn)
         plugin.multi_receive(sample_events)
-        expect(plugin.instance_variable_get(:@logger)).to have_received(:error).with("Error uploading to Scalyr (will backoff-retry)",
+        expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
           {
             :error_class=>"Scalyr::Common::Client::ServerError",
             :batch_num=>1,

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -1071,7 +1071,6 @@ describe LogStash::Outputs::Scalyr do
       it "throws on invalid hostname" do
         config = {
             'api_write_token' => '1234',
-            'perform_connectivity_check' => false,
             'scalyr_server' => 'https://agent.invalid.foo.scalyr.com',
             'perform_connectivity_check' => true
         }
@@ -1082,7 +1081,6 @@ describe LogStash::Outputs::Scalyr do
       it "throws on invalid api key" do
         config = {
             'api_write_token' => '1234',
-            'perform_connectivity_check' => false,
             'scalyr_server' => 'https://agent.scalyr.com',
             'perform_connectivity_check' => true
         }


### PR DESCRIPTION
Small change to increase default number of maximum retries on failure from 5 to 15.

With the previous value of 5, this gave the client a maximum number of 60 seconds of retrying before it gave up and sent messages to DLQ. With this change, the client will now attempt to retry up to 12 minutes (~60 seconds for first 5 retry attempts, then 10 + 60 for subsequent ones) before giving up and sending events to DLQ if all the retry attempts are unsuccessful.