### PR TITLE
Allow user to specify DataSet event severity field

### DIFF
--- a/.circleci/docker/pipeline/scalyr.conf
+++ b/.circleci/docker/pipeline/scalyr.conf
@@ -1,4 +1,4 @@
-input { 
+input {
   file {
     path => "ORIGIN1_INFILE"
   }
@@ -9,16 +9,18 @@ filter {
       "output_attribute1" => "output_value1"
       "output_attribute2" => "output_value2"
       "output_attribute3" => "output_value3"
+      "severity" => 4
     }
     add_tag => [ "tag_t1", "tag_t2" ]
   }
-}  
+}
 output {
  scalyr {
    api_write_token => 'SCALYR_API_KEY'
    scalyr_server => 'SCALYR_SERVER'
    ssl_verify_peer => true
    serverhost_field => 'host'
+   severity_field => 'severity'
    ssl_ca_bundle_path => '/etc/pki/tls/certs/ca-bundle.crt'
    logfile_field => 'path'
    use_hostname_for_serverhost => true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## 0.2.5.beta
 
-* Allow user to specify value for the DataSet event severity field. "severity" field is a special
-  top level event field which specifies the event severity (log level).
+* Allow user to specify value for the DataSet event severity  (``sev``) field. "sev" field is a
+  special top level event field which denotes the event severity (log level).
 
-  To enable this functionality, user needs to configure "severity_field" plugin config option and
+  To enable this functionality, user needs to configure ``severity_field`` plugin config option and
   set it to the logstash event field which carries the severity field value. This field value
-  needs to be an integer and contains value from 0 to 6.
+  needs to be an integer and contain a value from 0 to 6 (inclusive).
 
 ## 0.2.4.beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Beta
 
+## 0.2.5.beta
+
+* Allow user to specify value for the DataSet event severity field. "severity" field is a special
+  top level event field which specifies the event severity (log level).
+
+  To enable this functionality, user needs to configure "severity_field" plugin config option and
+  set it to the logstash event field which carries the severity field value. This field value
+  needs to be an integer and contains value from 0 to 6.
+
 ## 0.2.4.beta
 
 * Experimental zstandard support - in development, not to be used in production.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,37 @@ output {
   }
 ```
 
+## Notes on severity field handling
+
+``severity`` is a special top level DataSet event field which includes event severity / log level.
+
+To enable this functionality, user needs to define ``severity_field`` plugin config option. This
+config option tells the plugin which Logstash event field carries the value for the severity field.
+
+The actual value needs to be an integer between 0 and 6 inclusive. Those values are mapping to different
+severity / log levels on DataSet server side as shown below:
+
+- 0 -> finest
+- 1 -> trace
+- 2 -> debut
+- 3 -> info
+- 4 -> warning
+- 5 -> error
+- 6 -> fatal / emergency / critical
+
+```
+output {
+ scalyr {
+   api_write_token => 'SCALYR_API_KEY'
+   ...
+   severity_field => 'severity',
+ }
+}
+```
+
+In the example above, value for the DataSet severity field should be included in the ``severity``
+Logstash event field.
+
 ## Options
 
 - The Scalyr API write token, these are available at https://www.scalyr.com/keys.  This is the only compulsory configuration field required for proper upload

--- a/README.md
+++ b/README.md
@@ -86,15 +86,15 @@ output {
   }
 ```
 
-## Notes on severity field handling
+## Notes on severity (sev) attribute handling
 
-``severity`` is a special top level DataSet event field which includes event severity / log level.
+``sev`` is a special top level DataSet event field which denotes the event severity / log level.
 
 To enable this functionality, user needs to define ``severity_field`` plugin config option. This
 config option tells the plugin which Logstash event field carries the value for the severity field.
 
-The actual value needs to be an integer between 0 and 6 inclusive. Those values are mapping to different
-severity / log levels on DataSet server side as shown below:
+The actual value needs to be an integer between 0 and 6 inclusive. Those values are mapped to
+different severity / log levels on DataSet server side as shown below:
 
 - 0 -> finest
 - 1 -> trace
@@ -116,6 +116,9 @@ output {
 
 In the example above, value for the DataSet severity field should be included in the ``severity``
 Logstash event field.
+
+In case the field value doesn't contain a valid severity number (0 - 6), ``sev`` field won't be
+set on the event object to prevent API from rejecting an invalid request.
 
 ## Options
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -878,7 +878,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       end
 
       # optionally set severity (if available and valid)
-      if @severity_field and severity
+      if @severity_field and not severity_int.nil?
         scalyr_event[:sev] = severity_int
       end
 

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -310,10 +310,13 @@ describe LogStash::Outputs::Scalyr do
         end
 
         expect(body['events'][14]['attrs'].fetch('severity', nil)).to eq(-1)
+        expect(body['events'][14].key?("sev")).to eq(false)
         expect(body['events'][14]['sev']).to eq(nil)
         expect(body['events'][15]['attrs'].fetch('severity', nil)).to eq(7)
+        expect(body['events'][15].key?("sev")).to eq(false)
         expect(body['events'][15]['sev']).to eq(nil)
         expect(body['events'][16]['attrs'].fetch('severity', nil)).to eq("invalid")
+        expect(body['events'][16].key?("sev")).to eq(false)
         expect(body['events'][16]['sev']).to eq(nil)
       end
 
@@ -381,10 +384,13 @@ describe LogStash::Outputs::Scalyr do
         end
 
         expect(body['events'][14]['attrs'].fetch('severity', nil)).to eq(-1)
+        expect(body['events'][14].key?("sev")).to eq(false)
         expect(body['events'][14]['sev']).to eq(nil)
         expect(body['events'][15]['attrs'].fetch('severity', nil)).to eq(7)
+        expect(body['events'][15].key?("sev")).to eq(false)
         expect(body['events'][15]['sev']).to eq(nil)
         expect(body['events'][16]['attrs'].fetch('severity', nil)).to eq("invalid")
+        expect(body['events'][16].key?("sev")).to eq(false)
         expect(body['events'][16]['sev']).to eq(nil)
       end
     end

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -358,7 +358,7 @@ describe LogStash::Outputs::Scalyr do
 
       it "works correctly when severity event attribute is not specified but severity field is not set" do
         # Since severity_field config option is not set, severity field should be treated as a
-        # regulat event attribute and not as s a special top level event field
+        # regular event attribute and not as s a special top level Event.sev field
         plugin = LogStash::Outputs::Scalyr.new({
                                                    'api_write_token' => '1234',
                                                    'perform_connectivity_check' => false,

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -56,6 +56,20 @@ describe LogStash::Outputs::Scalyr do
     events
   }
 
+  let(:sample_events_with_severity) {
+    events = []
+    for i in 0..6 do
+      e = LogStash::Event.new
+      e.set('source_host', "my host #{i}")
+      e.set('source_file', "my file #{i}")
+      e.set('severity', i)
+      e.set('seq', i)
+      e.set('nested', {'a'=>1, 'b'=>[3,4,5]})
+      e.set('tags', ['t1', 't2', 't3'])
+      events.push(e)
+    end
+    events
+  }
   describe "#build_multi_event_request_array" do
 
     context "test get_stats and send_status" do
@@ -222,6 +236,66 @@ describe LogStash::Outputs::Scalyr do
         expect(logattrs2.fetch(EVENT_LEVEL_SERVER_HOST_ATTRIBUTE_NAME, nil)).to eq('my host 3')
         expect(logattrs2.fetch('logfile', nil)).to eq('/logstash/my host 3')
         expect(logattrs2.fetch('tags', nil)).to eq(['t1', 't2', 't3'])
+      end
+    end
+
+    context "when severity field is configured" do
+      it "works correctly when severity event attribute is specified" do
+        plugin = LogStash::Outputs::Scalyr.new({
+                                                   'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
+                                                   'severity_field' => 'severity',
+                                               })
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        result = plugin.build_multi_event_request_array(sample_events_with_severity)
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(7)
+
+        (0..6).each do |index|
+          expect(body['events'][index]['attrs'].fetch('severity', nil)).to eq(nil)
+          expect(body['events'][index]['attrs'].fetch('sev', nil)).to eq(nil)
+          expect(body['events'][index]['sev']).to eq(index)
+        end
+      end
+
+      it "works correctly when severity event attribute is not specified" do
+        plugin = LogStash::Outputs::Scalyr.new({
+                                                   'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
+                                                   'severity_field' => 'severity',
+                                               })
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        result = plugin.build_multi_event_request_array(sample_events)
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(3)
+
+        (0..2).each do |index|
+          expect(body['events'][index]['attrs'].fetch('severity', nil)).to eq(nil)
+          expect(body['events'][index]['attrs'].fetch('sev', nil)).to eq(nil)
+          expect(body['events'][index]['sev']).to eq(nil)
+        end
+      end
+
+      it "works correctly when severity event attribute is not specified but severity field is not set" do
+        # Since severity_field config option is not set, severity field should be treated as a
+        # regulat event attribute and not as s a special top level event field
+        plugin = LogStash::Outputs::Scalyr.new({
+                                                   'api_write_token' => '1234',
+                                                   'perform_connectivity_check' => false,
+                                                   'severity_field' => nil,
+                                               })
+        allow(plugin).to receive(:send_status).and_return(nil)
+        plugin.register
+        result = plugin.build_multi_event_request_array(sample_events_with_severity)
+        body = JSON.parse(result[0][:body])
+        expect(body['events'].size).to eq(7)
+
+        (0..6).each do |index|
+          expect(body['events'][index]['attrs'].fetch('severity', nil)).to eq(index)
+          expect(body['events'][index]['sev']).to eq(nil)
+        end
       end
     end
 


### PR DESCRIPTION
## Description

This pull request allows users to set  top level``severity`` (sev) field on the DataSet event.

This field contains the event severity / log level and it's special since it's a top level event field (same as ``id``, ``thread`` and ``log`` event attribute) and not part of the event attributes aka ``event.attrs`` field.

## Usage

To use this functionality, user needs to configure ``severity_field`` plugin config option. This config option tells the plugin which Logstash event field contains the severity value.

For example:

```
output {
 scalyr {
   api_write_token => 'SCALYR_API_KEY'
   ...
   severity_field => 'severity',
 }
}
```

In this example, ``severity`` Logstash event field value carries the severity value. Actual field value must be an integer between 0 to 6 (inclusive), from finest / most verbose to the most critical / least verbose.

This numeric severity field value is mapped to a severity level on the DataSet server side as shown below:

- 0 -> finest
- 1 -> trace
- 2 -> debut
- 3 -> info
- 4 -> warning
- 5 -> error
- 6 -> fatal / emergency / critical

## Notes

For backward compatibility reasons this functionality is disabled by default (``severity_field`` plugin config option value defaults to ``nil``). It needs to be explicitly enabled by the end user (opt-int) by configuring ``severity_field`` plugin config option.