### PR TITLE
Don't include spec/ directory (tests + tests fixtures) inside the ruby gem

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -82,3 +82,8 @@ jobs:
         run: |
           ls -la logstash-output-scalyr/
           [ ! -d logstash-output-scalyr/vendor ]
+
+      - name: Confirm gem doesn't contain spec/ directory
+        run: |
+          ls -la logstash-output-scalyr/
+          [ ! -d logstash-output-scalyr/spec/ ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beta
 
+## 0.2.8.beta
+
+* Update ``.gemspec`` gem metadata to not include ``spec/`` directory with the tests and tests
+  fixtures with the actual production gem file.
+
 ## 0.2.7.beta
 
 * SSL cert validation code has been simplified. Now ``ssl_ca_bundle_path`` config option

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 


### PR DESCRIPTION
This pull request updates gemspec metadata so we don't include spec/ directory which contains tests + tests fixtures with the .gem itself - there is no need to include those with the gem (and it slightly reduces the gem size).