### PR TITLE
CT-594 Do not retry requests with payloads that are too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   sending the request to the DLQ, skip the retries go directly to sending the
   request to the DLQ.
 
+  To be notified when an event fails to be ingested for whatever reason, create
+  an alert using the query: ``parser='logstash_plugin_metrics'
+  failed_events_processed > 0``. Instructions on how to create an alert can be
+  found in our docs here: https://scalyr.com/help/alerts
+
 ## 0.2.7.beta
 
 * SSL cert validation code has been simplified. Now ``ssl_ca_bundle_path`` config option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 * Update ``.gemspec`` gem metadata to not include ``spec/`` directory with the tests and tests
   fixtures with the actual production gem file.
 
+* Do not retry requests that will never be accepted by the server.
+  Specifically, any request that returns HTTP Status code 413 is too large, and
+  will never be accepted. Instead of simply retrying for 10 minutes before
+  sending the request to the DLQ, skip the retries go directly to sending the
+  request to the DLQ.
+
 ## 0.2.7.beta
 
 * SSL cert validation code has been simplified. Now ``ssl_ca_bundle_path`` config option

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ if Dir.exist?(logstash_path) && use_logstash_source
 end
 
 group :test do
-  gem "webmock"
+  gem "webmock", "3.18.1"
 
   # Require the specific version of `json` used in logstash while testing
   gem 'json', '1.8.6'

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ if Dir.exist?(logstash_path) && use_logstash_source
 end
 
 group :test do
-  gem "webmock", "3.18.1"
+  gem "webmock"
 
   # Require the specific version of `json` used in logstash while testing
   gem 'json', '1.8.6'

--- a/README.md
+++ b/README.md
@@ -505,10 +505,9 @@ To deploy the current code on your machine run these commands:
 
 ```
 rm -rf vendor/
-bundle check --path vendor/bundle || bundle install --deployment
+bundle install
 curl -u RUBY_USER:RUBY_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials
-bundle exec rake vendor
 bundle exec rspec
 bundle exec rake publish_gem
 ```
@@ -518,10 +517,9 @@ Or as an alternative if ``rake publish_gem`` task doesn't appear to work for wha
 
 ```
 rm -rf vendor/
-bundle check --path vendor/bundle || bundle install --deployment
+bundle install
 curl -u RUBY_USER:RUBY_PASSWORD https://rubygems.org/api/v1/api_key.yaml > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials
-bundle exec rake vendor
 bundle exec rspec
 rvm use jruby
 bundle exec gem build logstash-output-scalyr.gemspec

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -515,7 +515,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           if defined?(e.body) and e.body
             exc_data[:body] = Scalyr::Common::Util.truncate(e.body, 512)
           end
-          exc_data[:payload] = "\tSample payload: #{request[:body][0,1024]}..."
+          exc_data[:payload] = "\tSample payload: #{multi_event_request[:body][0,1024]}..."
           log_retry_failure(multi_event_request, exc_data, 0, 0)
           next
         rescue Scalyr::Common::Client::ServerError, Scalyr::Common::Client::ClientError => e

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -658,7 +658,9 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
     }
     if exc_data[:code] == 413
       message = "Failed to send #{multi_event_request[:logstash_events].length} events due to exceeding maximum request size. Not retrying non-retriable request."
-      @logger.error(message, :error_data => exc_data, :sample_events => sample_events)
+      # For PayloadTooLargeError we already include sample Scalyr payload in exc_data so there is no need
+      # to include redundant sample Logstash event objects
+      @logger.error(message, :error_data => exc_data)
     else
       message = "Failed to send #{multi_event_request[:logstash_events].length} events after #{exc_retries} tries."
       @logger.error(message, :error_data => exc_data, :sample_events => sample_events, :retries => exc_retries, :sleep_time => exc_sleep)

--- a/lib/scalyr/common/client.rb
+++ b/lib/scalyr/common/client.rb
@@ -27,12 +27,18 @@ end
 # An exception that signifies the Scalyr server received the upload request but dropped it
 #---------------------------------------------------------------------------------------------------------------------
 class RequestDroppedError < ServerError;
+  def initialize(msg=nil, code=nil, url=nil, body=nil, e_class="Scalyr::Common::Client::RequestDroppedError")
+    super(msg, code, url, body, e_class)
+  end
 end
 
 #---------------------------------------------------------------------------------------------------------------------
 # An exception that signifies the Scalyr server received the upload request but dropped it due to it being too large.
 #---------------------------------------------------------------------------------------------------------------------
 class PayloadTooLargeError < ServerError;
+  def initialize(msg=nil, code=nil, url=nil, body=nil, e_class="Scalyr::Common::Client::PayloadTooLargeError")
+    super(msg, code, url, body, e_class)
+  end
 end
 
 #---------------------------------------------------------------------------------------------------------------------

--- a/lib/scalyr/constants.rb
+++ b/lib/scalyr/constants.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-PLUGIN_VERSION = "v0.2.7.beta"
+PLUGIN_VERSION = "v0.2.8.beta"
 
 # Special event level attribute name which can be used for setting event level serverHost attribute
 EVENT_LEVEL_SERVER_HOST_ATTRIBUTE_NAME = '__origServerHost'

--- a/logstash-output-scalyr.gemspec
+++ b/logstash-output-scalyr.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-scalyr'
-  s.version         = '0.2.7.beta'
+  s.version         = '0.2.8.beta'
   s.licenses = ['Apache-2.0']
   s.summary = "Scalyr output plugin for Logstash"
   s.description     = "Sends log data collected by Logstash to Scalyr (https://www.scalyr.com)"


### PR DESCRIPTION
Simplest possible solution to get things moving again.

Create a new error class for HTTP response code 413, and if a 413 is returned, raise that error. When PayloadTooLargeError is raised, we skip the normal retry logic and go straight to logging the error, and either sending the request to the DLQ if enabled, or we drop it.

CT-594