### PR TITLE
Update data which is included in the error message context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Update context which is logged with errors which represent HTTP requests which are retried
   to also include ``total_retries_so_far`` and ``total_sleep_time_so_far`` attribute.
 
+* Add new ``retry_backoff_factor`` config option with which user can change a default value of 2
+  for the retry backoff factor (exponential delay).
+
 ## 0.2.8.beta
 
 * Update ``.gemspec`` gem metadata to not include ``spec/`` directory with the tests and tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Beta
 
+## 0.2.9.beta
+
+* Update context which is logged with errors which represent HTTP requests which are retried
+  to also include ``total_retries_so_far`` and ``total_sleep_time_so_far`` attribute.
+
 ## 0.2.8.beta
 
 * Update ``.gemspec`` gem metadata to not include ``spec/`` directory with the tests and tests

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -535,6 +535,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
               :record_count => multi_event_request[:record_count],
               :payload_size => multi_event_request[:body].bytesize,
               :will_retry_in_seconds => sleep_interval,
+              :total_retries_so_far => exc_retries,
+              :total_sleep_time_so_far => exc_sleep,
           }
           exc_data[:code] = e.code if e.code
           if @logger.debug? and defined?(e.body) and e.body

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -132,6 +132,9 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
   # Set max interval in seconds between bulk retries.
   config :retry_max_interval, :validate => :number, :default => 64
 
+  # Back off factor for retries. We default to 2 (exponential retry delay).
+  config :retry_backoff_factor, :validate => :number, :default => 2
+
   # Whether or not to verify the connection to Scalyr, only set to false for debugging.
   config :ssl_verify_peer, :validate => :boolean, :default => true
 
@@ -1240,7 +1243,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
 
   # Helper method that gets the next sleep time for exponential backoff, capped at a defined maximum
   def get_sleep_sec(current_interval)
-    doubled = current_interval * 2
+    doubled = current_interval * @retry_backoff_factor
     doubled > @retry_max_interval ? @retry_max_interval : doubled
   end
 

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -350,6 +350,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
       :successful_events_processed => 0,
       :failed_events_processed => 0,
       :total_retry_count => 0,
+      :total_retry_duration_secs => 0,
       :total_java_class_cast_errors => 0
     }
     @plugin_metrics = get_new_metrics
@@ -524,6 +525,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           exc_retries += 1
           @stats_lock.synchronize do
             @multi_receive_statistics[:total_retry_count] += 1
+            @multi_receive_statistics[:total_retry_duration_secs] += sleep_interval
           end
           message = "Error uploading to Scalyr (will backoff-retry)"
           exc_data = {
@@ -580,6 +582,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
           exc_retries += 1
           @stats_lock.synchronize do
             @multi_receive_statistics[:total_retry_count] += 1
+            @multi_receive_statistics[:total_retry_duration_secs] += sleep_interval
           end
           retry if @running and exc_retries < @max_retries
           log_retry_failure(multi_event_request, exc_data, exc_retries, exc_sleep)

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -535,6 +535,8 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
               :record_count => multi_event_request[:record_count],
               :payload_size => multi_event_request[:body].bytesize,
               :will_retry_in_seconds => sleep_interval,
+              # to get actual value which excludes this next retry user needs to
+              # add -1 to exc_retries and add -sleep_interval to exc_sleep
               :total_retries_so_far => exc_retries,
               :total_sleep_time_so_far => exc_sleep,
           }

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -58,6 +58,8 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://agent.scalyr.com/addEvents",
+                  :total_retries_so_far=>1,
+                  :total_sleep_time_so_far=>0.4,
                   :will_retry_in_seconds=>0.4,
                   :body=>"{\n  \"message\": \"Couldn't decode API token ...234.\",\n  \"status\": \"error/client/badParam\"\n}"
                 }
@@ -109,6 +111,8 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://agent.scalyr.com/addEvents",
+                  :total_retries_so_far=>1,
+                  :total_sleep_time_so_far=>0.4,
                   :will_retry_in_seconds=>0.4
                 }
               )
@@ -154,6 +158,8 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://invalid.mitm.should.fail.test.agent.scalyr.com/addEvents",
+                  :total_retries_so_far=>1,
+                  :total_sleep_time_so_far=>0.4,
                   :will_retry_in_seconds=>0.4
                 }
               )
@@ -213,6 +219,8 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :total_retries_so_far=>1,
+            :total_sleep_time_so_far=>0.2,
             :will_retry_in_seconds=>0.2,
             :body=>"stubbed response"
           }
@@ -248,6 +256,8 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :total_retries_so_far=>1,
+            :total_sleep_time_so_far=>0.2,
             :will_retry_in_seconds=>0.2,
             :body=>"stubbed response"
           }
@@ -323,6 +333,8 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :total_retries_so_far=>1,
+            :total_sleep_time_so_far=>0.2,
             :will_retry_in_seconds=>0.2,
             :body=>("0123456789" * 50) + "012345678..."
           }


### PR DESCRIPTION
This pull request updates context hash which is included / logged as part of the requests which are retried to also include `total_retries_so_far` and `total_sleep_time_so_far` attributes.

Both of those values can be inferred from existing `will_retry_in_seconds` attribute (since we use fixed delays and back off factor with no jitter), but having direct access makes some queries / searches a bit simpler (and those values can also be graphed directly).