### PR TITLE
Implement error / exception type specific HTTP request retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Beta
 
+## 0.2.10.beta
+
+* Introduce new plugin config options which allows failed HTTP request retry options to be
+  configured differently for a different set of errors.
+
+  Those options should be left as-is, unless instructed differently by the DataSet support team.
+
+* Use longer retry delays where we don't want to retry as soon as possible (e.g. deploy related
+  errors or client being throttled by the server).
+
 ## 0.2.9.beta
 
 * Update context which is logged with errors which represent HTTP requests which are retried

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -1339,6 +1339,10 @@ class RetryStateTracker
     end
   end
 
+  def get_state()
+    @STATE
+  end
+
   # Helper method that performs synchronous sleep for a certain time interval for a specific
   # error and updates interal error specific state. It also returns updates internal state
   # specific to that error.

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -519,14 +519,12 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
         exc_commonly_retried = false
 
         # We use new and clean retry state object for each request
-        def is_plugin_running()
-          # Since @running is only available directly on the output plugin instance and we don't
-          # want to create a cyclic reference between output and state tracker instance we pass
-          # this method to the state tracker
-          @running
-        end
+        # Since @running is only available directly on the output plugin instance and we don't
+        # want to create a cyclic reference between output and state tracker instance we pass
+        # this lambda method to the state tracker
+        is_plugin_running = lambda { @running }
 
-        retry_state = RetryStateTracker.new(@config, method(:is_plugin_running))
+        retry_state = RetryStateTracker.new(@config, is_plugin_running)
 
         begin
           # For some reason a retry on the multi_receive may result in the request array containing `nil` elements, we

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -562,6 +562,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             @multi_receive_statistics[:total_retry_count] += 1
             @multi_receive_statistics[:total_retry_duration_secs] += updated_state[:sleep_interval]
           end
+
           message = "Error uploading to Scalyr (will backoff-retry)"
           exc_data = {
               :error_class => e.e_class,
@@ -595,11 +596,6 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
             # all other failed uploads should be warning
             @logger.warn(message, exc_data)
             exc_commonly_retried = false
-          end
-
-          @stats_lock.synchronize do
-            @multi_receive_statistics[:total_retry_count] += 1
-            @multi_receive_statistics[:total_retry_duration_secs] += updated_state[:sleep_interval]
           end
 
           retry if @running and updated_state[:retries] < updated_state[:options][:max_retries]

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -1340,7 +1340,7 @@ class RetryStateTracker
   end
 
   # Helper method that performs synchronous sleep for a certain time interval for a specific
-  # error and updates interal error specific state. It also returns updates internal state
+  # error and updates internal error specific state. It also returns updated internal state
   # specific to that error.
   def sleep_for_error_and_update_state(error)
     # Sleep for a specific duration

--- a/lib/logstash/outputs/scalyr.rb
+++ b/lib/logstash/outputs/scalyr.rb
@@ -577,7 +577,7 @@ class LogStash::Outputs::Scalyr < LogStash::Outputs::Base
               # to get actual value which excludes this next retry user needs to
               # add -1 to exc_retries and add -sleep_interval to exc_sleep
               :total_retries_so_far => updated_state[:retries],
-              :total_sleep_time_so_far => updated_state[:sleep],
+              :total_sleep_time_so_far => updated_state[:sleep_interval],
           }
           exc_data[:code] = e.code if e.code
           if @logger.debug? and defined?(e.body) and e.body
@@ -1283,11 +1283,12 @@ end
 class RetryStateTracker
 
   def initialize(plugin_config, is_plugin_running_method)
+    # :sleep_interval stores total amount (in seconds) we have slept / waited due to retries so far
+    # :retries stores number of times we have retried so far
     @STATE = {
       :deploy_errors => {
         :sleep_interval => plugin_config["retry_initial_interval_deploy_errors"],
         :retries => 0,
-        :sleep => 0,
         :options => {
           :retry_initial_interval => plugin_config["retry_initial_interval_deploy_errors"],
           :max_retries => plugin_config["max_retries_deploy_errors"],
@@ -1298,7 +1299,6 @@ class RetryStateTracker
       :throttling_errors => {
         :sleep_interval => plugin_config["retry_initial_interval_throttling_errors"],
         :retries => 0,
-        :sleep => 0,
         :options => {
           :retry_initial_interval => plugin_config["retry_initial_interval_throttling_errors"],
           :max_retries => plugin_config["max_retries_throttling_errors"],
@@ -1309,7 +1309,6 @@ class RetryStateTracker
       :other_errors => {
         :sleep_interval => plugin_config["retry_initial_interval"],
         :retries => 0,
-        :sleep => 0,
         :options => {
           :retry_initial_interval => plugin_config["retry_initial_interval"],
           :max_retries => plugin_config["max_retries"],

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -43,6 +43,12 @@ describe LogStash::Outputs::Scalyr do
                 'max_retries' => 2,
                 'retry_max_interval' => 2,
                 'retry_initial_interval' => 0.2,
+                'max_retries_throttling_errors' => 2,
+                'retry_max_interval_throttling_errors' => 2,
+                'retry_initial_interval_throttling_errors' => 0.2,
+                'max_retries_deploy_errors' => 2,
+                'retry_max_interval_deploy_errors' => 2,
+                'retry_initial_interval_deploy_errors' => 0.2,
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
@@ -76,6 +82,12 @@ describe LogStash::Outputs::Scalyr do
                 'max_retries' => 2,
                 'retry_max_interval' => 2,
                 'retry_initial_interval' => 0.2,
+                'max_retries_throttling_errors' => 2,
+                'retry_max_interval_throttling_errors' => 2,
+                'retry_initial_interval_throttling_errors' => 0.2,
+                'max_retries_deploy_errors' => 2,
+                'retry_max_interval_deploy_errors' => 2,
+                'retry_initial_interval_deploy_errors' => 0.2,
               })
 
               expect {
@@ -95,6 +107,12 @@ describe LogStash::Outputs::Scalyr do
                 'max_retries' => 2,
                 'retry_max_interval' => 2,
                 'retry_initial_interval' => 0.2,
+                'max_retries_throttling_errors' => 2,
+                'retry_max_interval_throttling_errors' => 2,
+                'retry_initial_interval_throttling_errors' => 0.2,
+                'max_retries_deploy_errors' => 2,
+                'retry_max_interval_deploy_errors' => 2,
+                'retry_initial_interval_deploy_errors' => 0.2,
                 'ssl_ca_bundle_path' => temp_file.path
               })
               plugin.register
@@ -144,6 +162,12 @@ describe LogStash::Outputs::Scalyr do
                 'max_retries' => 2,
                 'retry_max_interval' => 2,
                 'retry_initial_interval' => 0.2,
+                'max_retries_throttling_errors' => 2,
+                'retry_max_interval_throttling_errors' => 2,
+                'retry_initial_interval_throttling_errors' => 0.2,
+                'max_retries_deploy_errors' => 2,
+                'retry_max_interval_deploy_errors' => 2,
+                'retry_initial_interval_deploy_errors' => 0.2,
               })
               plugin.register
               plugin.instance_variable_set(:@running, false)
@@ -180,6 +204,12 @@ describe LogStash::Outputs::Scalyr do
             'max_retries' => 15,
             'retry_max_interval' => 0.2,
             'retry_initial_interval' => 0.1,
+            'max_retries_throttling_errors' => 2,
+            'retry_max_interval_throttling_errors' => 2,
+            'retry_initial_interval_throttling_errors' => 0.2,
+            'max_retries_deploy_errors' => 2,
+            'retry_max_interval_deploy_errors' => 2,
+            'retry_initial_interval_deploy_errors' => 0.2,
           })
           plugin.register
           allow(plugin.instance_variable_get(:@logger)).to receive(:error)
@@ -203,6 +233,12 @@ describe LogStash::Outputs::Scalyr do
           'max_retries' => 2,
           'retry_max_interval' => 0.2,
           'retry_initial_interval' => 0.1,
+          'max_retries_throttling_errors' => 2,
+          'retry_max_interval_throttling_errors' => 2,
+          'retry_initial_interval_throttling_errors' => 0.2,
+          'max_retries_deploy_errors' => 2,
+          'retry_max_interval_deploy_errors' => 2,
+          'retry_initial_interval_deploy_errors' => 0.2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -240,6 +276,12 @@ describe LogStash::Outputs::Scalyr do
           'max_retries' => 2,
           'retry_max_interval' => 0.2,
           'retry_initial_interval' => 0.1,
+          'max_retries_throttling_errors' => 2,
+          'retry_max_interval_throttling_errors' => 2,
+          'retry_initial_interval_throttling_errors' => 0.2,
+          'max_retries_deploy_errors' => 2,
+          'retry_max_interval_deploy_errors' => 2,
+          'retry_initial_interval_deploy_errors' => 0.2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -277,6 +319,12 @@ describe LogStash::Outputs::Scalyr do
           'max_retries' => 2,
           'retry_max_interval' => 0.2,
           'retry_initial_interval' => 0.1,
+          'max_retries_throttling_errors' => 2,
+          'retry_max_interval_throttling_errors' => 2,
+          'retry_initial_interval_throttling_errors' => 0.2,
+          'max_retries_deploy_errors' => 2,
+          'retry_max_interval_deploy_errors' => 2,
+          'retry_initial_interval_deploy_errors' => 0.2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -317,6 +365,12 @@ describe LogStash::Outputs::Scalyr do
             'max_retries' => 2,
             'retry_max_interval' => 0.2,
             'retry_initial_interval' => 0.1,
+            'max_retries_throttling_errors' => 2,
+            'retry_max_interval_throttling_errors' => 2,
+            'retry_initial_interval_throttling_errors' => 0.2,
+            'max_retries_deploy_errors' => 2,
+            'retry_max_interval_deploy_errors' => 2,
+            'retry_initial_interval_deploy_errors' => 0.2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -355,6 +409,12 @@ describe LogStash::Outputs::Scalyr do
             'max_retries' => 2,
             'retry_max_interval' => 0.2,
             'retry_initial_interval' => 0.1,
+            'max_retries_throttling_errors' => 2,
+            'retry_max_interval_throttling_errors' => 2,
+            'retry_initial_interval_throttling_errors' => 0.2,
+            'max_retries_deploy_errors' => 2,
+            'retry_max_interval_deploy_errors' => 2,
+            'retry_initial_interval_deploy_errors' => 0.2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)

--- a/spec/logstash/outputs/scalyr_integration_spec.rb
+++ b/spec/logstash/outputs/scalyr_integration_spec.rb
@@ -64,8 +64,11 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://agent.scalyr.com/addEvents",
+                  :max_retries=>2,
+                  :retry_backoff_factor=>2,
+                  :retry_max_interval=>2,
                   :total_retries_so_far=>1,
-                  :total_sleep_time_so_far=>0.4,
+                  :total_sleep_time_so_far=>0.2,
                   :will_retry_in_seconds=>0.4,
                   :body=>"{\n  \"message\": \"Couldn't decode API token ...234.\",\n  \"status\": \"error/client/badParam\"\n}"
                 }
@@ -129,8 +132,11 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://agent.scalyr.com/addEvents",
+                  :max_retries=>2,
+                  :retry_backoff_factor=>2,
+                  :retry_max_interval=>2,
                   :total_retries_so_far=>1,
-                  :total_sleep_time_so_far=>0.4,
+                  :total_sleep_time_so_far=>0.2,
                   :will_retry_in_seconds=>0.4
                 }
               )
@@ -182,8 +188,11 @@ describe LogStash::Outputs::Scalyr do
                   :record_count=>3,
                   :total_batches=>1,
                   :url=>"https://invalid.mitm.should.fail.test.agent.scalyr.com/addEvents",
+                  :max_retries=>2,
+                  :retry_backoff_factor=>2,
+                  :retry_max_interval=>2,
                   :total_retries_so_far=>1,
-                  :total_sleep_time_so_far=>0.4,
+                  :total_sleep_time_so_far=>0.2,
                   :will_retry_in_seconds=>0.4
                 }
               )
@@ -231,7 +240,7 @@ describe LogStash::Outputs::Scalyr do
           'perform_connectivity_check' => false,
           'ssl_ca_bundle_path' => EXAMPLE_COME_CA_CERTS_PATH,
           'max_retries' => 2,
-          'retry_max_interval' => 0.2,
+          'retry_max_interval' => 2,
           'retry_initial_interval' => 0.1,
           'max_retries_throttling_errors' => 2,
           'retry_max_interval_throttling_errors' => 2,
@@ -255,8 +264,11 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :max_retries=>2,
+            :retry_backoff_factor=>2,
+            :retry_max_interval=>2,
             :total_retries_so_far=>1,
-            :total_sleep_time_so_far=>0.2,
+            :total_sleep_time_so_far=>0.1,
             :will_retry_in_seconds=>0.2,
             :body=>"stubbed response"
           }
@@ -279,9 +291,11 @@ describe LogStash::Outputs::Scalyr do
           'max_retries_throttling_errors' => 2,
           'retry_max_interval_throttling_errors' => 2,
           'retry_initial_interval_throttling_errors' => 0.2,
+          'retry_backoff_factor_throttling_errors' => 2,
           'max_retries_deploy_errors' => 2,
           'retry_max_interval_deploy_errors' => 2,
           'retry_initial_interval_deploy_errors' => 0.2,
+          'retry_backoff_factor_deploy_errors' => 2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -290,7 +304,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.multi_receive(sample_events)
         expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
           {
-            :error_class=>"Scalyr::Common::Client::ServerError",
+            :error_class=>"Scalyr::Common::Client::DeployWindowError",
             :batch_num=>1,
             :code=>500,
             :message=>"Invalid JSON response from server",
@@ -298,9 +312,12 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :max_retries=>2,
+            :retry_backoff_factor=>2,
+            :retry_max_interval=>2,
             :total_retries_so_far=>1,
             :total_sleep_time_so_far=>0.2,
-            :will_retry_in_seconds=>0.2,
+            :will_retry_in_seconds=>0.4,
             :body=>"stubbed response"
           }
         )
@@ -371,6 +388,7 @@ describe LogStash::Outputs::Scalyr do
             'max_retries_deploy_errors' => 2,
             'retry_max_interval_deploy_errors' => 2,
             'retry_initial_interval_deploy_errors' => 0.2,
+            'retry_backoff_factor_deploy_errors' => 2,
         })
         plugin.register
         plugin.instance_variable_set(:@running, false)
@@ -379,7 +397,7 @@ describe LogStash::Outputs::Scalyr do
         plugin.multi_receive(sample_events)
         expect(plugin.instance_variable_get(:@logger)).to have_received(:warn).with("Error uploading to Scalyr (will backoff-retry)",
           {
-            :error_class=>"Scalyr::Common::Client::ServerError",
+            :error_class=>"Scalyr::Common::Client::DeployWindowError",
             :batch_num=>1,
             :code=>500,
             :message=>"Invalid JSON response from server",
@@ -387,9 +405,12 @@ describe LogStash::Outputs::Scalyr do
             :record_count=>3,
             :total_batches=>1,
             :url=>"https://agent.scalyr.com/addEvents",
+            :max_retries=>2,
+            :retry_backoff_factor=>2,
+            :retry_max_interval=>2,
             :total_retries_so_far=>1,
             :total_sleep_time_so_far=>0.2,
-            :will_retry_in_seconds=>0.2,
+            :will_retry_in_seconds=>0.4,
             :body=>("0123456789" * 50) + "012345678..."
           }
         )

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -1260,5 +1260,125 @@ describe LogStash::Outputs::Scalyr do
         expect { plugin.register }.to raise_error(LogStash::ConfigurationError, /Received 401 from Scalyr API during/)
       end
     end
+
+
+    context "RetryStateTracker" do
+      mock_config = {
+        'max_retries' => 2,
+        'retry_max_interval' => 2,
+        'retry_initial_interval' => 0.11,
+        'retry_backoff_factor' => 2.0,
+
+        'max_retries_deploy_errors' => 4,
+        'retry_max_interval_deploy_errors' => 2,
+        'retry_initial_interval_deploy_errors' => 0.12,
+        'retry_backoff_factor_deploy_errors' => 1.2,
+
+        'max_retries_throttling_errors' => 3,
+        'retry_max_interval_throttling_errors' => 2,
+        'retry_initial_interval_throttling_errors' => 0.13,
+        'retry_backoff_factor_throttling_errors' => 1.1,
+      }
+
+      mock_other_error = Manticore::UnknownException.new
+      mock_deploy_error_1 = Scalyr::Common::Client::DeployWindowError.new(code=530)
+      mock_deploy_error_2 = Scalyr::Common::Client::DeployWindowError.new(code=500)
+      mock_client_throttled_error = Scalyr::Common::Client::ClientThrottledError.new(code=429)
+
+      it "correctly tracks state across different error types" do
+        def mock_is_plugin_running()
+          true
+        end
+
+        state_tracker = RetryStateTracker.new(mock_config, mock_is_plugin_running)
+
+        # Verify initial state
+        state = state_tracker.get_state
+
+        expect(state[:other_errors]).to eq({
+          :sleep_interval => 0.11,
+          :retries => 0,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.11,
+            :max_retries => 2,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 2.0
+          }
+        })
+
+        expect(state[:deploy_errors]).to eq({
+          :sleep_interval => 0.12,
+          :retries => 0,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.12,
+            :max_retries => 4,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 1.2
+          }
+        })
+
+        expect(state[:throttling_errors]).to eq({
+          :sleep_interval => 0.13,
+          :retries => 0,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.13,
+            :max_retries => 3,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 1.1
+          }
+        })
+
+        # Update internal state and verify it's updated correctly
+        state_tracker.sleep_for_error_and_update_state(mock_other_error)
+        state_tracker.sleep_for_error_and_update_state(mock_deploy_error_1)
+        state_tracker.sleep_for_error_and_update_state(mock_deploy_error_2)
+        state_tracker.sleep_for_error_and_update_state(mock_other_error)
+        state_tracker.sleep_for_error_and_update_state(mock_client_throttled_error)
+        state_tracker.sleep_for_error_and_update_state(mock_other_error)
+        state_tracker.sleep_for_error_and_update_state(mock_client_throttled_error)
+
+        state = state_tracker.get_state
+
+
+        expect(state[:other_errors]).to eq({
+          :sleep_interval => 0.88,
+          :retries => 3,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.11,
+            :max_retries => 2,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 2.0
+          }
+        })
+
+        expect(state[:deploy_errors]).to eq({
+          :sleep_interval => 0.17279999999999998,
+          :retries => 2,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.12,
+            :max_retries => 4,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 1.2
+          }
+        })
+
+        expect(state[:throttling_errors]).to eq({
+          :sleep_interval => 0.15730000000000002,
+          :retries => 2,
+          :sleep => 0,
+          :options => {
+            :retry_initial_interval => 0.13,
+            :max_retries => 3,
+            :retry_max_interval => 2,
+            :retry_backoff_factor => 1.1
+          }
+        })
+      end
+    end
   end
 end

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -1281,15 +1281,12 @@ describe LogStash::Outputs::Scalyr do
       }
 
       mock_other_error = Manticore::UnknownException.new
-      mock_deploy_error_1 = Scalyr::Common::Client::DeployWindowError.new(code=530)
-      mock_deploy_error_2 = Scalyr::Common::Client::DeployWindowError.new(code=500)
-      mock_client_throttled_error = Scalyr::Common::Client::ClientThrottledError.new(code=429)
+      mock_deploy_error_1 = Scalyr::Common::Client::DeployWindowError.new(nil, 530)
+      mock_deploy_error_2 = Scalyr::Common::Client::DeployWindowError.new(nil, 500)
+      mock_client_throttled_error = Scalyr::Common::Client::ClientThrottledError.new(nil, 429)
 
       it "correctly tracks state across different error types" do
-        def mock_is_plugin_running()
-          true
-        end
-
+        mock_is_plugin_running = lambda { true }
         state_tracker = RetryStateTracker.new(mock_config, mock_is_plugin_running)
 
         # Verify initial state

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -1295,7 +1295,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:other_errors]).to eq({
           :sleep_interval => 0.11,
           :retries => 0,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.11,
             :max_retries => 2,
@@ -1307,7 +1306,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:deploy_errors]).to eq({
           :sleep_interval => 0.12,
           :retries => 0,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.12,
             :max_retries => 4,
@@ -1319,7 +1317,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:throttling_errors]).to eq({
           :sleep_interval => 0.13,
           :retries => 0,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.13,
             :max_retries => 3,
@@ -1343,7 +1340,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:other_errors]).to eq({
           :sleep_interval => 0.88,
           :retries => 3,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.11,
             :max_retries => 2,
@@ -1355,7 +1351,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:deploy_errors]).to eq({
           :sleep_interval => 0.17279999999999998,
           :retries => 2,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.12,
             :max_retries => 4,
@@ -1367,7 +1362,6 @@ describe LogStash::Outputs::Scalyr do
         expect(state[:throttling_errors]).to eq({
           :sleep_interval => 0.15730000000000002,
           :retries => 2,
-          :sleep => 0,
           :options => {
             :retry_initial_interval => 0.13,
             :max_retries => 3,

--- a/spec/logstash/outputs/scalyr_spec.rb
+++ b/spec/logstash/outputs/scalyr_spec.rb
@@ -1293,8 +1293,9 @@ describe LogStash::Outputs::Scalyr do
         state = state_tracker.get_state
 
         expect(state[:other_errors]).to eq({
-          :sleep_interval => 0.11,
           :retries => 0,
+          :sleep => 0,
+          :sleep_interval => 0.11,
           :options => {
             :retry_initial_interval => 0.11,
             :max_retries => 2,
@@ -1304,8 +1305,9 @@ describe LogStash::Outputs::Scalyr do
         })
 
         expect(state[:deploy_errors]).to eq({
-          :sleep_interval => 0.12,
           :retries => 0,
+          :sleep => 0,
+          :sleep_interval => 0.12,
           :options => {
             :retry_initial_interval => 0.12,
             :max_retries => 4,
@@ -1315,8 +1317,9 @@ describe LogStash::Outputs::Scalyr do
         })
 
         expect(state[:throttling_errors]).to eq({
-          :sleep_interval => 0.13,
           :retries => 0,
+          :sleep => 0,
+          :sleep_interval => 0.13,
           :options => {
             :retry_initial_interval => 0.13,
             :max_retries => 3,
@@ -1336,10 +1339,10 @@ describe LogStash::Outputs::Scalyr do
 
         state = state_tracker.get_state
 
-
         expect(state[:other_errors]).to eq({
-          :sleep_interval => 0.88,
           :retries => 3,
+          :sleep => 0.77,
+          :sleep_interval => 0.88,
           :options => {
             :retry_initial_interval => 0.11,
             :max_retries => 2,
@@ -1349,8 +1352,9 @@ describe LogStash::Outputs::Scalyr do
         })
 
         expect(state[:deploy_errors]).to eq({
-          :sleep_interval => 0.17279999999999998,
           :retries => 2,
+          :sleep => 0.264,
+          :sleep_interval => 0.17279999999999998,
           :options => {
             :retry_initial_interval => 0.12,
             :max_retries => 4,
@@ -1360,8 +1364,9 @@ describe LogStash::Outputs::Scalyr do
         })
 
         expect(state[:throttling_errors]).to eq({
-          :sleep_interval => 0.15730000000000002,
           :retries => 2,
+          :sleep => 0.273,
+          :sleep_interval => 0.15730000000000002,
           :options => {
             :retry_initial_interval => 0.13,
             :max_retries => 3,


### PR DESCRIPTION
## Description

This pull request implements error specific failed HTTP request retrying.

This change allows us to reduce unnecessary load on the client and the server in situations where it makes no sense to try to retry as fast as possible (e.g. during deploy window or when the client is throttled by the server).

## Background, Context

We noticed that during our deploy times when a short unavailability (~30 seconds) is expected when queue servers are getting restarted in a rolling fashion, logstash clients cause a lot of unnecessary load on the backend when they are trying to retry very fast when this happens.

To reduce this load, this pull request implements error type specific request retrying settings and state tracking.

## Proposed Implementation

In this PR I introduce new `RetryStateTracker` abstraction which allows us to track and update retry state for specific set of errors. It's also responsible for sleeping appropriate amount of time (depending on the error class and current state).

Since DataSet API can return different errors for the same retried request we need to keep track state on per error class basis and we can't use a simpler implementation where we only have a single state object.

Right now errors are grouped into the following categories for which retries can be configured separately:

* Deploy related errors - here we want to use longer initial retry delay, something along the lines pf 20-30 seconds.
* Client being throttled related errors - here we also want to use longer retry delay. We will start with some reasonable default value, once server side implements ``Retry-After`` header for 429 responses, we will use that value for the initial retry delay.
* Other errors (things such as temporary network errors, hiccups, etc.) - previously all the errors fell into this category. Here we do want to use a relatively short initial retry delay since based on our instrumentation and data, most of those networks errors are indeed successfully retried on first retry (which only results in a total wait time / pipeline being blocked for 2 seconds or so).

The implementation also introduces a bunch of new plugin config option which allows error specific retry settings to be adjusted.

It's worth noting that this does add some complexity (which I'm not a big fan of), but once we establish good default values those settings should never really be changed by the end user unless they have a very specific need or are instructed to do so by the DataSet support.

## TODO

- [x] Direct unit tests for ``RetryStateTracker`` abstraction
- [x] Update existing integration tests to verify / exercise error specific retries

## Other notes

While working on this change I noticed that we don't correctly update internal retry related stats / metrics when encountering ``ServerError`` and ``ClientError`` errors - we only updated it when encountering other errors for which we didn't have a specific catch clause so I fixed that as well.

## Future Optimizations

Once backend code is updated to return `Retry-After` header for 429 responses, code will be updated to use this for the retry internal for throttling errors.