### PR TITLE
Add secrets scanning workflow

### DIFF
--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -1,0 +1,79 @@
+name: TruffleHog Secrets Scan
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  actions: write  # Needed for skip-duplicate-jobs job
+  contents: read
+
+jobs:
+  # Special job which automatically cancels old runs for the same branch, prevents runs for the
+  # same file set which has already passed, etc.
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
+        with:
+          cancel_others: 'true'
+          github_token: ${{ github.token }}
+
+  TruffleHog:
+    runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'main' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: scan-pr
+        uses: trufflesecurity/trufflehog@main
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified
+            --exclude-paths=${{ inputs.exclude-paths }}
+
+      - name: scan-push
+        uses: trufflesecurity/trufflehog@main
+        if: ${{ github.event_name == 'push' }}
+        with:
+          path: ./
+          base: ""
+          head: ${{ github.ref_name }}
+          extra_args: --debug --only-verified
+
+      # As part of cron trigger we scan the whole repo directory.
+      # NOTE: Since trufflehog GHA is meant to be used in context of push / pr it can't be
+      # used dorectly to scan the whole repo directory. This may take a while, but it's good idea
+      # to run it on a daily basis.
+      - name: scan-cron
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          docker run --rm -v "$PWD:/workdir" trufflesecurity/trufflehog:latest git \
+            file:///workdir --fail --no-update --debug --only-verified
+
+      - name: Notify Slack on Failure
+        if: ${{ failure() && github.ref_name == 'master' }}
+        uses: act10ns/slack@ed1309ab9862e57e9e583e51c7889486b9a00b0f # v2.0.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+          steps: ${{ toJson(steps) }}
+          channel: '#eng-dataset-o11y'


### PR DESCRIPTION
This pull request adds a workflow which uses trufflehog to automatically scan files and commits for secrets on push, PR and as part of a daily cron trigger.